### PR TITLE
better display of current device status.

### DIFF
--- a/GatewayApp/Frontend/Plantmonitor.Website/src/features/deviceConfiguration/+page.svelte
+++ b/GatewayApp/Frontend/Plantmonitor.Website/src/features/deviceConfiguration/+page.svelte
@@ -77,27 +77,35 @@
 					<tr>
 						<th>IP</th>
 						<th>Action</th>
-						<th>Data</th>
 					</tr>
 				</thead>
 				<tbody>
 					<tr>
-						<td>{device.ip}</td>
-						<td class="d-flex flex-row justify-content-between">
+						<td class="col-md-3">
+							{#if device.health != undefined}
+								<span class="badge bg-success">{device.ip}</span><br />
+								<span>{device.health.deviceName}</span><br />
+								<span>{device.health.deviceId}</span>
+							{:else}
+								<span class="badge bg-danger">{device.ip}</span>
+							{/if}
+						</td>
+						<td>
 							<button on:click={() => configureDevice(device.ip)} class="btn btn-primary">
 								Configure
 							</button>
-							<button on:click={() => showPreviewImage(device.ip)} class="btn btn-primary">
-								Preview Image
-							</button>
-							<button on:click={() => testMovement(device.ip)} class="btn btn-primary">
-								Test Movement
-							</button>
+							{#if device.health != undefined}
+								<button on:click={() => showPreviewImage(device.ip)} class="btn btn-primary">
+									Preview Image
+								</button>
+								<button on:click={() => testMovement(device.ip)} class="btn btn-primary">
+									Test Movement
+								</button>
+							{/if}
 							<button on:click={() => openConsole(device.ip)} class="btn btn-primary">
 								Open Console
 							</button>
 						</td>
-						<td>{device.health?.toJSON()}</td>
 					</tr>
 				</tbody>
 			</table>

--- a/PlantMonitorControl/Install/install.sh
+++ b/PlantMonitorControl/Install/install.sh
@@ -13,3 +13,4 @@ sudo cp ./Install/PlantMonitorStart.service /lib/systemd/system/
 sudo chmod 644 /lib/systemd/system/PlantMonitorStart.service 
 sudo systemctl daemon-reload
 sudo systemctl enable PlantMonitorStart.service
+sudo systemctl start PlantMonitorStart.service


### PR DESCRIPTION
#7
When enabling PlantMonitorStart service during setup, the service should be started afterwards