### PR TITLE
13 capture video

### DIFF
--- a/GatewayApp/Frontend/Plantmonitor.Website/package-lock.json
+++ b/GatewayApp/Frontend/Plantmonitor.Website/package-lock.json
@@ -7,6 +7,9 @@
 		"": {
 			"name": "plantmonitor.website",
 			"version": "0.0.1",
+			"dependencies": {
+				"mirada": "^0.0.15"
+			},
 			"devDependencies": {
 				"@fontsource/fira-mono": "^4.5.10",
 				"@neoconfetti/svelte": "^1.0.0",
@@ -53,9 +56,9 @@
 			}
 		},
 		"node_modules/@esbuild/aix-ppc64": {
-			"version": "0.19.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.19.12.tgz",
-			"integrity": "sha512-bmoCYyWdEL3wDQIVbcyzRyeKLgk2WtWLTWz1ZIAZF/EGbNOwSA6ew3PftJ1PqMiOOGu0OyFMzG53L0zqIpPeNA==",
+			"version": "0.20.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.20.2.tgz",
+			"integrity": "sha512-D+EBOJHXdNZcLJRBkhENNG8Wji2kgc9AZ9KiPr1JuZjsNtyHzrsfLRrY0tk2H2aoFu6RANO1y1iPPUCDYWkb5g==",
 			"cpu": [
 				"ppc64"
 			],
@@ -69,9 +72,9 @@
 			}
 		},
 		"node_modules/@esbuild/android-arm": {
-			"version": "0.19.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.19.12.tgz",
-			"integrity": "sha512-qg/Lj1mu3CdQlDEEiWrlC4eaPZ1KztwGJ9B6J+/6G+/4ewxJg7gqj8eVYWvao1bXrqGiW2rsBZFSX3q2lcW05w==",
+			"version": "0.20.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.20.2.tgz",
+			"integrity": "sha512-t98Ra6pw2VaDhqNWO2Oph2LXbz/EJcnLmKLGBJwEwXX/JAN83Fym1rU8l0JUWK6HkIbWONCSSatf4sf2NBRx/w==",
 			"cpu": [
 				"arm"
 			],
@@ -85,9 +88,9 @@
 			}
 		},
 		"node_modules/@esbuild/android-arm64": {
-			"version": "0.19.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.19.12.tgz",
-			"integrity": "sha512-P0UVNGIienjZv3f5zq0DP3Nt2IE/3plFzuaS96vihvD0Hd6H/q4WXUGpCxD/E8YrSXfNyRPbpTq+T8ZQioSuPA==",
+			"version": "0.20.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.20.2.tgz",
+			"integrity": "sha512-mRzjLacRtl/tWU0SvD8lUEwb61yP9cqQo6noDZP/O8VkwafSYwZ4yWy24kan8jE/IMERpYncRt2dw438LP3Xmg==",
 			"cpu": [
 				"arm64"
 			],
@@ -101,9 +104,9 @@
 			}
 		},
 		"node_modules/@esbuild/android-x64": {
-			"version": "0.19.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.19.12.tgz",
-			"integrity": "sha512-3k7ZoUW6Q6YqhdhIaq/WZ7HwBpnFBlW905Fa4s4qWJyiNOgT1dOqDiVAQFwBH7gBRZr17gLrlFCRzF6jFh7Kew==",
+			"version": "0.20.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.20.2.tgz",
+			"integrity": "sha512-btzExgV+/lMGDDa194CcUQm53ncxzeBrWJcncOBxuC6ndBkKxnHdFJn86mCIgTELsooUmwUm9FkhSp5HYu00Rg==",
 			"cpu": [
 				"x64"
 			],
@@ -117,9 +120,9 @@
 			}
 		},
 		"node_modules/@esbuild/darwin-arm64": {
-			"version": "0.19.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.19.12.tgz",
-			"integrity": "sha512-B6IeSgZgtEzGC42jsI+YYu9Z3HKRxp8ZT3cqhvliEHovq8HSX2YX8lNocDn79gCKJXOSaEot9MVYky7AKjCs8g==",
+			"version": "0.20.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.20.2.tgz",
+			"integrity": "sha512-4J6IRT+10J3aJH3l1yzEg9y3wkTDgDk7TSDFX+wKFiWjqWp/iCfLIYzGyasx9l0SAFPT1HwSCR+0w/h1ES/MjA==",
 			"cpu": [
 				"arm64"
 			],
@@ -133,9 +136,9 @@
 			}
 		},
 		"node_modules/@esbuild/darwin-x64": {
-			"version": "0.19.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.19.12.tgz",
-			"integrity": "sha512-hKoVkKzFiToTgn+41qGhsUJXFlIjxI/jSYeZf3ugemDYZldIXIxhvwN6erJGlX4t5h417iFuheZ7l+YVn05N3A==",
+			"version": "0.20.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.20.2.tgz",
+			"integrity": "sha512-tBcXp9KNphnNH0dfhv8KYkZhjc+H3XBkF5DKtswJblV7KlT9EI2+jeA8DgBjp908WEuYll6pF+UStUCfEpdysA==",
 			"cpu": [
 				"x64"
 			],
@@ -149,9 +152,9 @@
 			}
 		},
 		"node_modules/@esbuild/freebsd-arm64": {
-			"version": "0.19.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.19.12.tgz",
-			"integrity": "sha512-4aRvFIXmwAcDBw9AueDQ2YnGmz5L6obe5kmPT8Vd+/+x/JMVKCgdcRwH6APrbpNXsPz+K653Qg8HB/oXvXVukA==",
+			"version": "0.20.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.20.2.tgz",
+			"integrity": "sha512-d3qI41G4SuLiCGCFGUrKsSeTXyWG6yem1KcGZVS+3FYlYhtNoNgYrWcvkOoaqMhwXSMrZRl69ArHsGJ9mYdbbw==",
 			"cpu": [
 				"arm64"
 			],
@@ -165,9 +168,9 @@
 			}
 		},
 		"node_modules/@esbuild/freebsd-x64": {
-			"version": "0.19.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.19.12.tgz",
-			"integrity": "sha512-EYoXZ4d8xtBoVN7CEwWY2IN4ho76xjYXqSXMNccFSx2lgqOG/1TBPW0yPx1bJZk94qu3tX0fycJeeQsKovA8gg==",
+			"version": "0.20.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.20.2.tgz",
+			"integrity": "sha512-d+DipyvHRuqEeM5zDivKV1KuXn9WeRX6vqSqIDgwIfPQtwMP4jaDsQsDncjTDDsExT4lR/91OLjRo8bmC1e+Cw==",
 			"cpu": [
 				"x64"
 			],
@@ -181,9 +184,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-arm": {
-			"version": "0.19.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.19.12.tgz",
-			"integrity": "sha512-J5jPms//KhSNv+LO1S1TX1UWp1ucM6N6XuL6ITdKWElCu8wXP72l9MM0zDTzzeikVyqFE6U8YAV9/tFyj0ti+w==",
+			"version": "0.20.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.20.2.tgz",
+			"integrity": "sha512-VhLPeR8HTMPccbuWWcEUD1Az68TqaTYyj6nfE4QByZIQEQVWBB8vup8PpR7y1QHL3CpcF6xd5WVBU/+SBEvGTg==",
 			"cpu": [
 				"arm"
 			],
@@ -197,9 +200,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-arm64": {
-			"version": "0.19.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.19.12.tgz",
-			"integrity": "sha512-EoTjyYyLuVPfdPLsGVVVC8a0p1BFFvtpQDB/YLEhaXyf/5bczaGeN15QkR+O4S5LeJ92Tqotve7i1jn35qwvdA==",
+			"version": "0.20.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.20.2.tgz",
+			"integrity": "sha512-9pb6rBjGvTFNira2FLIWqDk/uaf42sSyLE8j1rnUpuzsODBq7FvpwHYZxQ/It/8b+QOS1RYfqgGFNLRI+qlq2A==",
 			"cpu": [
 				"arm64"
 			],
@@ -213,9 +216,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-ia32": {
-			"version": "0.19.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.19.12.tgz",
-			"integrity": "sha512-Thsa42rrP1+UIGaWz47uydHSBOgTUnwBwNq59khgIwktK6x60Hivfbux9iNR0eHCHzOLjLMLfUMLCypBkZXMHA==",
+			"version": "0.20.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.20.2.tgz",
+			"integrity": "sha512-o10utieEkNPFDZFQm9CoP7Tvb33UutoJqg3qKf1PWVeeJhJw0Q347PxMvBgVVFgouYLGIhFYG0UGdBumROyiig==",
 			"cpu": [
 				"ia32"
 			],
@@ -229,9 +232,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-loong64": {
-			"version": "0.19.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.19.12.tgz",
-			"integrity": "sha512-LiXdXA0s3IqRRjm6rV6XaWATScKAXjI4R4LoDlvO7+yQqFdlr1Bax62sRwkVvRIrwXxvtYEHHI4dm50jAXkuAA==",
+			"version": "0.20.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.20.2.tgz",
+			"integrity": "sha512-PR7sp6R/UC4CFVomVINKJ80pMFlfDfMQMYynX7t1tNTeivQ6XdX5r2XovMmha/VjR1YN/HgHWsVcTRIMkymrgQ==",
 			"cpu": [
 				"loong64"
 			],
@@ -245,9 +248,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-mips64el": {
-			"version": "0.19.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.19.12.tgz",
-			"integrity": "sha512-fEnAuj5VGTanfJ07ff0gOA6IPsvrVHLVb6Lyd1g2/ed67oU1eFzL0r9WL7ZzscD+/N6i3dWumGE1Un4f7Amf+w==",
+			"version": "0.20.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.20.2.tgz",
+			"integrity": "sha512-4BlTqeutE/KnOiTG5Y6Sb/Hw6hsBOZapOVF6njAESHInhlQAghVVZL1ZpIctBOoTFbQyGW+LsVYZ8lSSB3wkjA==",
 			"cpu": [
 				"mips64el"
 			],
@@ -261,9 +264,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-ppc64": {
-			"version": "0.19.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.19.12.tgz",
-			"integrity": "sha512-nYJA2/QPimDQOh1rKWedNOe3Gfc8PabU7HT3iXWtNUbRzXS9+vgB0Fjaqr//XNbd82mCxHzik2qotuI89cfixg==",
+			"version": "0.20.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.20.2.tgz",
+			"integrity": "sha512-rD3KsaDprDcfajSKdn25ooz5J5/fWBylaaXkuotBDGnMnDP1Uv5DLAN/45qfnf3JDYyJv/ytGHQaziHUdyzaAg==",
 			"cpu": [
 				"ppc64"
 			],
@@ -277,9 +280,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-riscv64": {
-			"version": "0.19.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.19.12.tgz",
-			"integrity": "sha512-2MueBrlPQCw5dVJJpQdUYgeqIzDQgw3QtiAHUC4RBz9FXPrskyyU3VI1hw7C0BSKB9OduwSJ79FTCqtGMWqJHg==",
+			"version": "0.20.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.20.2.tgz",
+			"integrity": "sha512-snwmBKacKmwTMmhLlz/3aH1Q9T8v45bKYGE3j26TsaOVtjIag4wLfWSiZykXzXuE1kbCE+zJRmwp+ZbIHinnVg==",
 			"cpu": [
 				"riscv64"
 			],
@@ -293,9 +296,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-s390x": {
-			"version": "0.19.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.19.12.tgz",
-			"integrity": "sha512-+Pil1Nv3Umes4m3AZKqA2anfhJiVmNCYkPchwFJNEJN5QxmTs1uzyy4TvmDrCRNT2ApwSari7ZIgrPeUx4UZDg==",
+			"version": "0.20.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.20.2.tgz",
+			"integrity": "sha512-wcWISOobRWNm3cezm5HOZcYz1sKoHLd8VL1dl309DiixxVFoFe/o8HnwuIwn6sXre88Nwj+VwZUvJf4AFxkyrQ==",
 			"cpu": [
 				"s390x"
 			],
@@ -309,9 +312,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-x64": {
-			"version": "0.19.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.19.12.tgz",
-			"integrity": "sha512-B71g1QpxfwBvNrfyJdVDexenDIt1CiDN1TIXLbhOw0KhJzE78KIFGX6OJ9MrtC0oOqMWf+0xop4qEU8JrJTwCg==",
+			"version": "0.20.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.20.2.tgz",
+			"integrity": "sha512-1MdwI6OOTsfQfek8sLwgyjOXAu+wKhLEoaOLTjbijk6E2WONYpH9ZU2mNtR+lZ2B4uwr+usqGuVfFT9tMtGvGw==",
 			"cpu": [
 				"x64"
 			],
@@ -325,9 +328,9 @@
 			}
 		},
 		"node_modules/@esbuild/netbsd-x64": {
-			"version": "0.19.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.19.12.tgz",
-			"integrity": "sha512-3ltjQ7n1owJgFbuC61Oj++XhtzmymoCihNFgT84UAmJnxJfm4sYCiSLTXZtE00VWYpPMYc+ZQmB6xbSdVh0JWA==",
+			"version": "0.20.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.20.2.tgz",
+			"integrity": "sha512-K8/DhBxcVQkzYc43yJXDSyjlFeHQJBiowJ0uVL6Tor3jGQfSGHNNJcWxNbOI8v5k82prYqzPuwkzHt3J1T1iZQ==",
 			"cpu": [
 				"x64"
 			],
@@ -341,9 +344,9 @@
 			}
 		},
 		"node_modules/@esbuild/openbsd-x64": {
-			"version": "0.19.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.19.12.tgz",
-			"integrity": "sha512-RbrfTB9SWsr0kWmb9srfF+L933uMDdu9BIzdA7os2t0TXhCRjrQyCeOt6wVxr79CKD4c+p+YhCj31HBkYcXebw==",
+			"version": "0.20.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.20.2.tgz",
+			"integrity": "sha512-eMpKlV0SThJmmJgiVyN9jTPJ2VBPquf6Kt/nAoo6DgHAoN57K15ZghiHaMvqjCye/uU4X5u3YSMgVBI1h3vKrQ==",
 			"cpu": [
 				"x64"
 			],
@@ -357,9 +360,9 @@
 			}
 		},
 		"node_modules/@esbuild/sunos-x64": {
-			"version": "0.19.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.19.12.tgz",
-			"integrity": "sha512-HKjJwRrW8uWtCQnQOz9qcU3mUZhTUQvi56Q8DPTLLB+DawoiQdjsYq+j+D3s9I8VFtDr+F9CjgXKKC4ss89IeA==",
+			"version": "0.20.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.20.2.tgz",
+			"integrity": "sha512-2UyFtRC6cXLyejf/YEld4Hajo7UHILetzE1vsRcGL3earZEW77JxrFjH4Ez2qaTiEfMgAXxfAZCm1fvM/G/o8w==",
 			"cpu": [
 				"x64"
 			],
@@ -373,9 +376,9 @@
 			}
 		},
 		"node_modules/@esbuild/win32-arm64": {
-			"version": "0.19.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.19.12.tgz",
-			"integrity": "sha512-URgtR1dJnmGvX864pn1B2YUYNzjmXkuJOIqG2HdU62MVS4EHpU2946OZoTMnRUHklGtJdJZ33QfzdjGACXhn1A==",
+			"version": "0.20.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.20.2.tgz",
+			"integrity": "sha512-GRibxoawM9ZCnDxnP3usoUDO9vUkpAxIIZ6GQI+IlVmr5kP3zUq+l17xELTHMWTWzjxa2guPNyrpq1GWmPvcGQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -389,9 +392,9 @@
 			}
 		},
 		"node_modules/@esbuild/win32-ia32": {
-			"version": "0.19.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.19.12.tgz",
-			"integrity": "sha512-+ZOE6pUkMOJfmxmBZElNOx72NKpIa/HFOMGzu8fqzQJ5kgf6aTGrcJaFsNiVMH4JKpMipyK+7k0n2UXN7a8YKQ==",
+			"version": "0.20.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.20.2.tgz",
+			"integrity": "sha512-HfLOfn9YWmkSKRQqovpnITazdtquEW8/SoHW7pWpuEeguaZI4QnCRW6b+oZTztdBnZOS2hqJ6im/D5cPzBTTlQ==",
 			"cpu": [
 				"ia32"
 			],
@@ -405,9 +408,9 @@
 			}
 		},
 		"node_modules/@esbuild/win32-x64": {
-			"version": "0.19.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.19.12.tgz",
-			"integrity": "sha512-T1QyPSDCyMXaO3pzBkF96E8xMkiRYbUEZADd29SyPGabqxMViNoii+NcK7eWJAEoU6RZyEm5lVSIjTmcdoB9HA==",
+			"version": "0.20.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.20.2.tgz",
+			"integrity": "sha512-N49X4lJX27+l9jbLKSqZ6bKNjzQvHaT8IIFUy+YIqmXQdjYCToGWwOItDrfby14c78aDd5NHQl29xingXfCdLQ==",
 			"cpu": [
 				"x64"
 			],
@@ -1396,6 +1399,25 @@
 			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
 			"dev": true
 		},
+		"node_modules/base64-js": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+			"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			]
+		},
 		"node_modules/binary-extensions": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
@@ -1424,6 +1446,29 @@
 			},
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/buffer": {
+			"version": "5.7.1",
+			"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+			"integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"dependencies": {
+				"base64-js": "^1.3.1",
+				"ieee754": "^1.1.13"
 			}
 		},
 		"node_modules/buffer-crc32": {
@@ -1581,6 +1626,14 @@
 				"node": ">= 0.6"
 			}
 		},
+		"node_modules/cross-fetch": {
+			"version": "3.1.8",
+			"resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.8.tgz",
+			"integrity": "sha512-cvA+JwZoU0Xq+h6WkMvAUqPEYy92Obet6UdKLfW60qn99ftItKjB5T+BkyWOFWe2pUyfQ+IJHmpOTznqk1M6Kg==",
+			"dependencies": {
+				"node-fetch": "^2.6.12"
+			}
+		},
 		"node_modules/cross-spawn": {
 			"version": "7.0.3",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -1728,9 +1781,9 @@
 			"dev": true
 		},
 		"node_modules/esbuild": {
-			"version": "0.19.12",
-			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.19.12.tgz",
-			"integrity": "sha512-aARqgq8roFBj054KvQr5f1sFu0D65G+miZRCuJyJ0G13Zwx7vRar5Zhn2tkQNzIXcBrNVsv/8stehpj+GAjgbg==",
+			"version": "0.20.2",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.20.2.tgz",
+			"integrity": "sha512-WdOOppmUNU+IbZ0PaDiTst80zjnrOkyJNHoKupIcVyU8Lvla3Ugx94VzkQ32Ijqd7UhHJy75gNWDMUekcrSJ6g==",
 			"dev": true,
 			"hasInstallScript": true,
 			"bin": {
@@ -1740,29 +1793,29 @@
 				"node": ">=12"
 			},
 			"optionalDependencies": {
-				"@esbuild/aix-ppc64": "0.19.12",
-				"@esbuild/android-arm": "0.19.12",
-				"@esbuild/android-arm64": "0.19.12",
-				"@esbuild/android-x64": "0.19.12",
-				"@esbuild/darwin-arm64": "0.19.12",
-				"@esbuild/darwin-x64": "0.19.12",
-				"@esbuild/freebsd-arm64": "0.19.12",
-				"@esbuild/freebsd-x64": "0.19.12",
-				"@esbuild/linux-arm": "0.19.12",
-				"@esbuild/linux-arm64": "0.19.12",
-				"@esbuild/linux-ia32": "0.19.12",
-				"@esbuild/linux-loong64": "0.19.12",
-				"@esbuild/linux-mips64el": "0.19.12",
-				"@esbuild/linux-ppc64": "0.19.12",
-				"@esbuild/linux-riscv64": "0.19.12",
-				"@esbuild/linux-s390x": "0.19.12",
-				"@esbuild/linux-x64": "0.19.12",
-				"@esbuild/netbsd-x64": "0.19.12",
-				"@esbuild/openbsd-x64": "0.19.12",
-				"@esbuild/sunos-x64": "0.19.12",
-				"@esbuild/win32-arm64": "0.19.12",
-				"@esbuild/win32-ia32": "0.19.12",
-				"@esbuild/win32-x64": "0.19.12"
+				"@esbuild/aix-ppc64": "0.20.2",
+				"@esbuild/android-arm": "0.20.2",
+				"@esbuild/android-arm64": "0.20.2",
+				"@esbuild/android-x64": "0.20.2",
+				"@esbuild/darwin-arm64": "0.20.2",
+				"@esbuild/darwin-x64": "0.20.2",
+				"@esbuild/freebsd-arm64": "0.20.2",
+				"@esbuild/freebsd-x64": "0.20.2",
+				"@esbuild/linux-arm": "0.20.2",
+				"@esbuild/linux-arm64": "0.20.2",
+				"@esbuild/linux-ia32": "0.20.2",
+				"@esbuild/linux-loong64": "0.20.2",
+				"@esbuild/linux-mips64el": "0.20.2",
+				"@esbuild/linux-ppc64": "0.20.2",
+				"@esbuild/linux-riscv64": "0.20.2",
+				"@esbuild/linux-s390x": "0.20.2",
+				"@esbuild/linux-x64": "0.20.2",
+				"@esbuild/netbsd-x64": "0.20.2",
+				"@esbuild/openbsd-x64": "0.20.2",
+				"@esbuild/sunos-x64": "0.20.2",
+				"@esbuild/win32-arm64": "0.20.2",
+				"@esbuild/win32-ia32": "0.20.2",
+				"@esbuild/win32-x64": "0.20.2"
 			}
 		},
 		"node_modules/escape-string-regexp": {
@@ -2105,6 +2158,14 @@
 				"node": "^10.12.0 || >=12.0.0"
 			}
 		},
+		"node_modules/file-type": {
+			"version": "12.4.2",
+			"resolved": "https://registry.npmjs.org/file-type/-/file-type-12.4.2.tgz",
+			"integrity": "sha512-UssQP5ZgIOKelfsaB5CuGAL+Y+q7EmONuiwF3N5HAH0t27rvrttgi6Ra9k/+DVaY9UF6+ybxu5pOXLUdA8N7Vg==",
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/fill-range": {
 			"version": "7.0.1",
 			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -2324,6 +2385,25 @@
 			"engines": {
 				"node": ">=16.17.0"
 			}
+		},
+		"node_modules/ieee754": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+			"integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			]
 		},
 		"node_modules/ignore": {
 			"version": "5.3.1",
@@ -2706,6 +2786,22 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/mirada": {
+			"version": "0.0.15",
+			"resolved": "https://registry.npmjs.org/mirada/-/mirada-0.0.15.tgz",
+			"integrity": "sha512-mbm4c+wjBVcmUzHRLv/TfOAq+iy03D24KwGxx8H+NSXkD5EOZV9zFWbVxTvZCc9XwR0FIUhryU/kQm12SMSQ3g==",
+			"dependencies": {
+				"buffer": "^5.4.3",
+				"cross-fetch": "^3.0.4",
+				"file-type": "^12.3.0",
+				"misc-utils-of-mine-generic": "^0.2.31"
+			}
+		},
+		"node_modules/misc-utils-of-mine-generic": {
+			"version": "0.2.45",
+			"resolved": "https://registry.npmjs.org/misc-utils-of-mine-generic/-/misc-utils-of-mine-generic-0.2.45.tgz",
+			"integrity": "sha512-WsG2zYiui2cdEbHF2pXmJfnjHb4zL+cy+PaYcLgIpMju98hwX89VbjlvGIfamCfEodbQ0qjCEvD3ocgkCXfMOQ=="
+		},
 		"node_modules/mkdirp": {
 			"version": "0.5.6",
 			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
@@ -2777,6 +2873,25 @@
 			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
 			"integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
 			"dev": true
+		},
+		"node_modules/node-fetch": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+			"integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+			"dependencies": {
+				"whatwg-url": "^5.0.0"
+			},
+			"engines": {
+				"node": "4.x || >=6.0.0"
+			},
+			"peerDependencies": {
+				"encoding": "^0.1.0"
+			},
+			"peerDependenciesMeta": {
+				"encoding": {
+					"optional": true
+				}
+			}
 		},
 		"node_modules/normalize-path": {
 			"version": "3.0.0",
@@ -2989,9 +3104,9 @@
 			}
 		},
 		"node_modules/postcss": {
-			"version": "8.4.35",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.35.tgz",
-			"integrity": "sha512-u5U8qYpBCpN13BsiEB0CbR1Hhh4Gc0zLFuedrHJKMctHCHAGrMdG0PRM/KErzAL3CU6/eckEtmHNB3x6e3c0vA==",
+			"version": "8.4.38",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.38.tgz",
+			"integrity": "sha512-Wglpdk03BSfXkHoQa3b/oulrotAkwrlLDRSOb9D0bN86FdRyE9lppSp33aHNPgBa0JKCoB+drFLZkQoRRYae5A==",
 			"dev": true,
 			"funding": [
 				{
@@ -3010,7 +3125,7 @@
 			"dependencies": {
 				"nanoid": "^3.3.7",
 				"picocolors": "^1.0.0",
-				"source-map-js": "^1.0.2"
+				"source-map-js": "^1.2.0"
 			},
 			"engines": {
 				"node": "^10 || ^12 || >=14"
@@ -3431,9 +3546,9 @@
 			}
 		},
 		"node_modules/source-map-js": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
-			"integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.0.tgz",
+			"integrity": "sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==",
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
@@ -3733,6 +3848,11 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/tr46": {
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+			"integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+		},
 		"node_modules/ts-api-utils": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.3.0.tgz",
@@ -3819,14 +3939,14 @@
 			"dev": true
 		},
 		"node_modules/vite": {
-			"version": "5.1.6",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-5.1.6.tgz",
-			"integrity": "sha512-yYIAZs9nVfRJ/AiOLCA91zzhjsHUgMjB+EigzFb6W2XTLO8JixBCKCjvhKZaye+NKYHCrkv3Oh50dH9EdLU2RA==",
+			"version": "5.2.8",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-5.2.8.tgz",
+			"integrity": "sha512-OyZR+c1CE8yeHw5V5t59aXsUPPVTHMDjEZz8MgguLL/Q7NblxhZUlTu9xSPqlsUO/y+X7dlU05jdhvyycD55DA==",
 			"dev": true,
 			"dependencies": {
-				"esbuild": "^0.19.3",
-				"postcss": "^8.4.35",
-				"rollup": "^4.2.0"
+				"esbuild": "^0.20.1",
+				"postcss": "^8.4.38",
+				"rollup": "^4.13.0"
 			},
 			"bin": {
 				"vite": "bin/vite.js"
@@ -3972,6 +4092,20 @@
 				"jsdom": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/webidl-conversions": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+			"integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+		},
+		"node_modules/whatwg-url": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+			"integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+			"dependencies": {
+				"tr46": "~0.0.3",
+				"webidl-conversions": "^3.0.0"
 			}
 		},
 		"node_modules/which": {

--- a/GatewayApp/Frontend/Plantmonitor.Website/package.json
+++ b/GatewayApp/Frontend/Plantmonitor.Website/package.json
@@ -33,5 +33,8 @@
 		"vite": "^5.0.3",
 		"vitest": "^1.2.0"
 	},
-	"type": "module"
+	"type": "module",
+	"dependencies": {
+		"mirada": "^0.0.15"
+	}
 }

--- a/GatewayApp/Frontend/Plantmonitor.Website/src/app.d.ts
+++ b/GatewayApp/Frontend/Plantmonitor.Website/src/app.d.ts
@@ -1,6 +1,9 @@
 // See https://kit.svelte.dev/docs/types#app
 // for information about these interfaces
 declare global {
+	interface Window {
+		cv: typeof import('mirada/dist/src/types/opencv/_types');
+	}
 	namespace App {
 		interface Error { }
 		// interface Locals {}

--- a/GatewayApp/Frontend/Plantmonitor.Website/src/app.html
+++ b/GatewayApp/Frontend/Plantmonitor.Website/src/app.html
@@ -6,6 +6,7 @@
 	<link rel="icon" href="%sveltekit.assets%/favicon.png" />
 	<link rel="stylesheet" href=".%sveltekit.assets%/bootstrap.min.css">
 	<script src="%sveltekit.assets%/bootstrap.min.js"></script>
+	<script src="%sveltekit.assets%/opencv.js"></script>
 	<meta name="viewport" content="width=device-width, initial-scale=1" />
 	%sveltekit.head%
 </head>

--- a/GatewayApp/Frontend/Plantmonitor.Website/src/features/deviceConfiguration/+page.svelte
+++ b/GatewayApp/Frontend/Plantmonitor.Website/src/features/deviceConfiguration/+page.svelte
@@ -10,7 +10,9 @@
 	import 'typeExtensions';
 	import { Task } from '~/types/task';
 	import { ImageTakingClient, MotorMovementClient } from '~/services/PlantMonitorControlApi';
+	import { CvInterop } from './CvInterop';
 
+	const videoCanvasId = 'videoCanvasId';
 	let configurationClient: DeviceConfigurationClient;
 	let devices: DeviceHealthState[] = [];
 	let previewImage = '';
@@ -65,6 +67,11 @@
 		if (device == undefined) return;
 		const imageTakingClient = new ImageTakingClient(`https://${device}`).withTimeout(10000);
 		previewVideo = await (await imageTakingClient.getVideoTest()).data.asBase64Url();
+		const canvas = document.getElementById(videoCanvasId) as HTMLCanvasElement;
+		new CvInterop().displayVideo(
+			previewVideo,
+			document.getElementById(videoCanvasId) as HTMLImageElement
+		);
 		console.log(previewVideo);
 	}
 	async function getDeviceStatus() {
@@ -138,11 +145,7 @@
 			{/if}
 		</div>
 		<div class="col-md-12">
-			{#if !previewVideo.isEmpty()}
-				<video src={previewVideo}>
-					<track kind="captions" />
-				</video>
-			{/if}
+			<img alt="Video" id={videoCanvasId} />
 		</div>
 		<div class="col-md-12" style="height:80vh;">
 			{#if !webSshLink.isEmpty()}

--- a/GatewayApp/Frontend/Plantmonitor.Website/src/features/deviceConfiguration/+page.svelte
+++ b/GatewayApp/Frontend/Plantmonitor.Website/src/features/deviceConfiguration/+page.svelte
@@ -65,6 +65,7 @@
 		if (device == undefined) return;
 		const imageTakingClient = new ImageTakingClient(`https://${device}`).withTimeout(10000);
 		previewVideo = await (await imageTakingClient.getVideoTest()).data.asBase64Url();
+		console.log(previewVideo);
 	}
 	async function getDeviceStatus() {
 		const client = new DeviceConfigurationClient();

--- a/GatewayApp/Frontend/Plantmonitor.Website/src/features/deviceConfiguration/CvInterop.ts
+++ b/GatewayApp/Frontend/Plantmonitor.Website/src/features/deviceConfiguration/CvInterop.ts
@@ -1,0 +1,49 @@
+import { Task } from "~/types/task";
+
+export class CvInterop {
+    extractImages(source: string, dest: HTMLCanvasElement) {
+        const video = new cv.VideoCapture(source);
+        const height = 480;
+        const width = 640;
+        const src = new cv.Mat(height, width, cv.CV_8UC4);
+        const fps = 30;
+        function processVideo() {
+            const begin = Date.now();
+            video.read(src);
+            cv.imshow(dest, src);
+            const delay = 1000 / fps - (Date.now() - begin);
+            setTimeout(processVideo, delay);
+        }
+        setTimeout(processVideo, 0);
+    }
+    async displayVideo(url: string, image: HTMLImageElement) {
+        const response = await fetch(url);
+        if (!response.ok) throw Error(response.status + ' ' + response.statusText)
+        if (!response.body) throw Error('ReadableStream not yet supported in this browser.')
+        const reader = response.body.getReader();
+        let imageBuffer: Uint8Array = new Uint8Array(1024 * 1024 * 1024);
+        let bytesRead = 0;
+        const headerBytes = [255, 216, 255, 224, 0, 16, 74, 70, 73, 70, 0];
+        const { done, value } = await reader.read();
+        if (done) return;
+        for (let index = 0; index < value.length; index++) {
+            let headerFound = false;
+            for (let hi = 0; hi < headerBytes.length; hi++) {
+                if (value[index + hi] != headerBytes[hi]) break;
+                if (hi == headerBytes.length - 1) headerFound = true;
+            }
+            if (headerFound) {
+                if (bytesRead < 100) continue;
+                const frame = URL.createObjectURL(new Blob([imageBuffer.subarray(0, bytesRead)], { type: "image/jpeg" }));
+                bytesRead = 0;
+                image.src = frame;
+                await Task.delay(1);
+                URL.revokeObjectURL(frame)
+                imageBuffer = new Uint8Array(1024 * 1024 * 1024);
+                imageBuffer[bytesRead++] = value[index];
+            }
+            else imageBuffer[bytesRead++] = value[index];
+        }
+    }
+}
+

--- a/PlantMonitorControl/Features/ImageTaking/RaspberryCameraInterop.cs
+++ b/PlantMonitorControl/Features/ImageTaking/RaspberryCameraInterop.cs
@@ -48,6 +48,7 @@ public class RaspberryCameraInterop() : ICameraInterop
         .WithContinuousStreaming()
         .WithVflip()
         .WithHflip()
+        .WithMJPEGVideoOptions(100)
         .WithResolution(640, 480);
         var args = builder.GetArguments();
         using var process = new ProcessRunner(_videoProcessSettings);

--- a/PlantMonitorControl/Features/ImageTaking/RaspberryCameraInterop.cs
+++ b/PlantMonitorControl/Features/ImageTaking/RaspberryCameraInterop.cs
@@ -1,7 +1,6 @@
-﻿using Iot.Device.Camera;
-using Iot.Device.Camera.Settings;
+﻿using Iot.Device.Camera.Settings;
 using Iot.Device.Common;
-using Plantmonitor.Shared.Extensions;
+using System.Diagnostics;
 
 namespace PlantMonitorControl.Features.MotorMovement;
 
@@ -45,27 +44,22 @@ public class RaspberryCameraInterop() : ICameraInterop
 
     public async Task<IResult> VideoStream()
     {
-        var test = await new Capture(_videoProcessSettings).CaptureVideo();
-        return Results.File(test, "video/mp4");
         var builder = new CommandOptionsBuilder()
         .WithContinuousStreaming()
         .WithVflip()
         .WithHflip()
-        .WithH264VideoOptions("baseline", "4", 15)
         .WithResolution(640, 480);
         var args = builder.GetArguments();
         using var process = new ProcessRunner(_videoProcessSettings);
 
-        using var file = File.Create("h264");
         var ms = new MemoryStream();
-        var task = await process.ContinuousRunAsync(args, file);
+        var task = await process.ContinuousRunAsync(args, ms);
         await Task.Delay(2000);
         process.Dispose();
-        try { await task; } catch (Exception ex) { Console.WriteLine(ex.Message); }
+        try { await task; Console.WriteLine("No Error"); } catch (Exception ex) { Console.WriteLine(ex.Message); }
+        var info = new ProcessStartInfo("pkill", $"-9 -f {_videoProcessSettings.Filename}");
+        new Process() { StartInfo = info }.Start();
         ms.Position = 0;
-        file.Flush();
-        file.Position = 0;
-        file.CopyTo(ms);
         var success = ms.Length > 1000;
         _deviceFunctional = success;
         _cameraFound |= success;
@@ -99,135 +93,5 @@ public class RaspberryCameraInterop() : ICameraInterop
         _deviceFunctional = success;
         _cameraFound |= success;
         return Results.File(ms, "image/png");
-    }
-}
-
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-
-internal class Capture
-{
-    private readonly ProcessSettings _processSettings;
-
-    public Capture(ProcessSettings processSettings)
-    {
-        _processSettings = processSettings;
-    }
-
-    private string CreateFilename(string extension)
-    {
-        var now = DateTime.Now;
-        var path = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
-        var filename = $"{now.Year:00}{now.Month:00}{now.Day:00}_{now.Hour:00}{now.Minute:00}{now.Second:00}{now.Millisecond:0000}.{extension}";
-        return Path.Combine(path, filename);
-    }
-
-    public async Task<string> CaptureStill()
-    {
-        var builder = new CommandOptionsBuilder()
-            .WithTimeout(1)
-            .WithVflip()
-            .WithHflip()
-            .WithPictureOptions(90, "jpg")
-            .WithResolution(640, 480);
-        var args = builder.GetArguments();
-
-        using var proc = new ProcessRunner(_processSettings);
-        Console.WriteLine("Using the following command line:");
-        Console.WriteLine(proc.GetFullCommandLine(args));
-        Console.WriteLine();
-
-        var filename = CreateFilename("jpg");
-        using var file = File.OpenWrite(filename);
-        await proc.ExecuteAsync(args, file);
-        return filename;
-    }
-
-    public async Task<string> CaptureVideo()
-    {
-        var builder = new CommandOptionsBuilder()
-            .WithContinuousStreaming(0)
-            .WithVflip()
-            .WithHflip()
-            .WithResolution(640, 480);
-        var args = builder.GetArguments();
-
-        using var proc = new ProcessRunner(_processSettings);
-        Console.WriteLine("Using the following command line:");
-        Console.WriteLine(proc.GetFullCommandLine(args));
-        Console.WriteLine();
-
-        var filename = CreateFilename("h264");
-        using var file = File.OpenWrite(filename);
-
-        /*
-        The following code will stop capturing after 5 seconds
-        We could do the same specifying ".WithContinuousStreaming(5000)" instead of 0
-        But the following code shows how to stop the capture programmatically
-        */
-
-        // The ContinuousRunAsync method offload the capture on a separate thread
-        var task = await proc.ContinuousRunAsync(args, file);
-        await Task.Delay(5000);
-        proc.Dispose();
-        // The following try/catch is needed to trash the OperationCanceledException triggered by the Dispose
-        try
-        {
-            await task;
-        }
-        catch (Exception)
-        {
-        }
-
-        return filename;
-    }
-
-    public async Task CaptureTimelapse()
-    {
-        // The false argument avoids the app to output to stdio
-        // Time lapse images will be directly saved on disk without
-        // writing anything on the terminal
-        // Alternatively, we can leave the default (true) and
-        // use the '.Remove' method
-        var builder = new CommandOptionsBuilder(false)
-            // .Remove(CommandOptionsBuilder.Get(Command.Output))
-            .WithOutput("image_%04d.jpg")
-            .WithTimeout(5000)
-            .WithTimelapse(1000)
-            .WithVflip()
-            .WithHflip()
-            .WithResolution(640, 480);
-        var args = builder.GetArguments();
-
-        using var proc = new ProcessRunner(_processSettings);
-        Console.WriteLine("Using the following command line:");
-        Console.WriteLine(proc.GetFullCommandLine(args));
-        Console.WriteLine();
-
-        // The ContinuousRunAsync method offload the capture on a separate thread
-        // the first await is tied the thread being run
-        // the second await is tied to the capture
-        var task = await proc.ContinuousRunAsync(args, default(Stream));
-        await task;
-    }
-
-    public async Task<IEnumerable<CameraInfo>> List()
-    {
-        var builder = new CommandOptionsBuilder()
-            .WithListCameras();
-        var args = builder.GetArguments();
-
-        using var proc = new ProcessRunner(_processSettings);
-        Console.WriteLine("Using the following command line:");
-        Console.WriteLine(proc.GetFullCommandLine(args));
-        Console.WriteLine();
-
-        var text = await proc.ExecuteReadOutputAsStringAsync(args);
-        Console.WriteLine($"Output being parsed:");
-        Console.WriteLine(text);
-        Console.WriteLine();
-
-        var cameras = await CameraInfo.From(text);
-        return cameras;
     }
 }

--- a/PlantMonitorControl/Features/ImageTaking/RaspberryCameraInterop.cs
+++ b/PlantMonitorControl/Features/ImageTaking/RaspberryCameraInterop.cs
@@ -1,4 +1,5 @@
-﻿using Iot.Device.Camera.Settings;
+﻿using Iot.Device.Camera;
+using Iot.Device.Camera.Settings;
 using Iot.Device.Common;
 using Plantmonitor.Shared.Extensions;
 
@@ -44,6 +45,8 @@ public class RaspberryCameraInterop() : ICameraInterop
 
     public async Task<IResult> VideoStream()
     {
+        var test = await new Capture(_videoProcessSettings).CaptureVideo();
+        return Results.File(test, "video/mp4");
         var builder = new CommandOptionsBuilder()
         .WithContinuousStreaming()
         .WithVflip()
@@ -53,12 +56,16 @@ public class RaspberryCameraInterop() : ICameraInterop
         var args = builder.GetArguments();
         using var process = new ProcessRunner(_videoProcessSettings);
 
+        using var file = File.Create("h264");
         var ms = new MemoryStream();
-        var task = await process.ContinuousRunAsync(args, ms);
+        var task = await process.ContinuousRunAsync(args, file);
         await Task.Delay(2000);
         process.Dispose();
-        await (task.Try(async (x) => await x, out _) ?? Task.CompletedTask);
+        try { await task; } catch (Exception ex) { Console.WriteLine(ex.Message); }
         ms.Position = 0;
+        file.Flush();
+        file.Position = 0;
+        file.CopyTo(ms);
         var success = ms.Length > 1000;
         _deviceFunctional = success;
         _cameraFound |= success;
@@ -92,5 +99,135 @@ public class RaspberryCameraInterop() : ICameraInterop
         _deviceFunctional = success;
         _cameraFound |= success;
         return Results.File(ms, "image/png");
+    }
+}
+
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+internal class Capture
+{
+    private readonly ProcessSettings _processSettings;
+
+    public Capture(ProcessSettings processSettings)
+    {
+        _processSettings = processSettings;
+    }
+
+    private string CreateFilename(string extension)
+    {
+        var now = DateTime.Now;
+        var path = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        var filename = $"{now.Year:00}{now.Month:00}{now.Day:00}_{now.Hour:00}{now.Minute:00}{now.Second:00}{now.Millisecond:0000}.{extension}";
+        return Path.Combine(path, filename);
+    }
+
+    public async Task<string> CaptureStill()
+    {
+        var builder = new CommandOptionsBuilder()
+            .WithTimeout(1)
+            .WithVflip()
+            .WithHflip()
+            .WithPictureOptions(90, "jpg")
+            .WithResolution(640, 480);
+        var args = builder.GetArguments();
+
+        using var proc = new ProcessRunner(_processSettings);
+        Console.WriteLine("Using the following command line:");
+        Console.WriteLine(proc.GetFullCommandLine(args));
+        Console.WriteLine();
+
+        var filename = CreateFilename("jpg");
+        using var file = File.OpenWrite(filename);
+        await proc.ExecuteAsync(args, file);
+        return filename;
+    }
+
+    public async Task<string> CaptureVideo()
+    {
+        var builder = new CommandOptionsBuilder()
+            .WithContinuousStreaming(0)
+            .WithVflip()
+            .WithHflip()
+            .WithResolution(640, 480);
+        var args = builder.GetArguments();
+
+        using var proc = new ProcessRunner(_processSettings);
+        Console.WriteLine("Using the following command line:");
+        Console.WriteLine(proc.GetFullCommandLine(args));
+        Console.WriteLine();
+
+        var filename = CreateFilename("h264");
+        using var file = File.OpenWrite(filename);
+
+        /*
+        The following code will stop capturing after 5 seconds
+        We could do the same specifying ".WithContinuousStreaming(5000)" instead of 0
+        But the following code shows how to stop the capture programmatically
+        */
+
+        // The ContinuousRunAsync method offload the capture on a separate thread
+        var task = await proc.ContinuousRunAsync(args, file);
+        await Task.Delay(5000);
+        proc.Dispose();
+        // The following try/catch is needed to trash the OperationCanceledException triggered by the Dispose
+        try
+        {
+            await task;
+        }
+        catch (Exception)
+        {
+        }
+
+        return filename;
+    }
+
+    public async Task CaptureTimelapse()
+    {
+        // The false argument avoids the app to output to stdio
+        // Time lapse images will be directly saved on disk without
+        // writing anything on the terminal
+        // Alternatively, we can leave the default (true) and
+        // use the '.Remove' method
+        var builder = new CommandOptionsBuilder(false)
+            // .Remove(CommandOptionsBuilder.Get(Command.Output))
+            .WithOutput("image_%04d.jpg")
+            .WithTimeout(5000)
+            .WithTimelapse(1000)
+            .WithVflip()
+            .WithHflip()
+            .WithResolution(640, 480);
+        var args = builder.GetArguments();
+
+        using var proc = new ProcessRunner(_processSettings);
+        Console.WriteLine("Using the following command line:");
+        Console.WriteLine(proc.GetFullCommandLine(args));
+        Console.WriteLine();
+
+        // The ContinuousRunAsync method offload the capture on a separate thread
+        // the first await is tied the thread being run
+        // the second await is tied to the capture
+        var task = await proc.ContinuousRunAsync(args, default(Stream));
+        await task;
+    }
+
+    public async Task<IEnumerable<CameraInfo>> List()
+    {
+        var builder = new CommandOptionsBuilder()
+            .WithListCameras();
+        var args = builder.GetArguments();
+
+        using var proc = new ProcessRunner(_processSettings);
+        Console.WriteLine("Using the following command line:");
+        Console.WriteLine(proc.GetFullCommandLine(args));
+        Console.WriteLine();
+
+        var text = await proc.ExecuteReadOutputAsStringAsync(args);
+        Console.WriteLine($"Output being parsed:");
+        Console.WriteLine(text);
+        Console.WriteLine();
+
+        var cameras = await CameraInfo.From(text);
+        return cameras;
     }
 }

--- a/PlantMonitorControl/Install/shellStart.sh
+++ b/PlantMonitorControl/Install/shellStart.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+sudo pkill -9 -f dotnet
+sudo /srv/dotnet build -c Release -o /srv/dist -r linux-arm --no-self-contained ~/PlantMonitor/PlantMonitorControl/PlantMonitorControl.csproj
+sudo /srv/dotnet /srv/dist/PlantMonitorControl.dll


### PR DESCRIPTION


### Commit messages for #13

- 679f022ea52d391fbaf6329fc5557d2970cbd9f7 added a simple script to create a local build of the PlantMonitorControl project for testing
- a621bcd3053b1c81fae47ce048feab4b7495fa43 sample, which serves a videostream only once over the api.
Frontend is currently not able to display the base64 encoded videostream

### Commit messages for #13

- 679f022ea52d391fbaf6329fc5557d2970cbd9f7 added a simple script to create a local build of the PlantMonitorControl project for testing
- a621bcd3053b1c81fae47ce048feab4b7495fa43 sample, which serves a videostream only once over the api.
Frontend is currently not able to display the base64 encoded videostream
- 0a76dbb377ed532a9c7c3f7065f3b7b8c28d45b7 documentation seems to be wrong. The video process does not exit cleanly and therefor subsequent video takings do not produce data. See this merge request:
https://github.com/dotnet/iot/pull/2165

Fix is using a pkill command to kill the video process.

### Commit messages for #13

- 679f022ea52d391fbaf6329fc5557d2970cbd9f7 added a simple script to create a local build of the PlantMonitorControl project for testing
- a621bcd3053b1c81fae47ce048feab4b7495fa43 sample, which serves a videostream only once over the api.
Frontend is currently not able to display the base64 encoded videostream
- 0a76dbb377ed532a9c7c3f7065f3b7b8c28d45b7 documentation seems to be wrong. The video process does not exit cleanly and therefor subsequent video takings do not produce data. See this merge request:
https://github.com/dotnet/iot/pull/2165

Fix is using a pkill command to kill the video process.
- 5d37552cd7978031e05700d17d277b789abbe396 added mirada for generation of type annotations for using opencv
- 8cf0cca9c696a1a3f754b72c7640cbc1fc85f0ed proof of concept to show video on the client.
The device serves a mjpeg video stream, which consists of individual jpeg images of JFIF type.
The bytestream is then scanned for the header and spliced into images for display