### PR TITLE
13 capture video

### DIFF
--- a/GatewayApp/Frontend/Plantmonitor.Website/package-lock.json
+++ b/GatewayApp/Frontend/Plantmonitor.Website/package-lock.json
@@ -9,6 +9,7 @@
 			"version": "0.0.1",
 			"dependencies": {
 				"@microsoft/signalr": "^8.0.0",
+				"@microsoft/signalr-protocol-msgpack": "^8.0.0",
 				"mirada": "^0.0.15"
 			},
 			"devDependencies": {
@@ -633,6 +634,23 @@
 				"fetch-cookie": "^2.0.3",
 				"node-fetch": "^2.6.7",
 				"ws": "^7.4.5"
+			}
+		},
+		"node_modules/@microsoft/signalr-protocol-msgpack": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@microsoft/signalr-protocol-msgpack/-/signalr-protocol-msgpack-8.0.0.tgz",
+			"integrity": "sha512-XtN5lUPVOtU96aqpB6z00o0TQayx5fmcf7CeQKDXF1flg8G96wtNCFXKb/p4sM/nvprjSmz0JiWQfc1TVXsa6Q==",
+			"dependencies": {
+				"@microsoft/signalr": ">=8.0.0",
+				"@msgpack/msgpack": "^2.7.0"
+			}
+		},
+		"node_modules/@msgpack/msgpack": {
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@msgpack/msgpack/-/msgpack-2.8.0.tgz",
+			"integrity": "sha512-h9u4u/jiIRKbq25PM+zymTyW6bhTzELvOoUd+AvYriWOAKpLGnIamaET3pnHYoI5iYphAHBI4ayx0MehR+VVPQ==",
+			"engines": {
+				"node": ">= 10"
 			}
 		},
 		"node_modules/@neoconfetti/svelte": {

--- a/GatewayApp/Frontend/Plantmonitor.Website/package.json
+++ b/GatewayApp/Frontend/Plantmonitor.Website/package.json
@@ -36,6 +36,7 @@
 	"type": "module",
 	"dependencies": {
 		"@microsoft/signalr": "^8.0.0",
+		"@microsoft/signalr-protocol-msgpack": "^8.0.0",
 		"mirada": "^0.0.15"
 	}
 }

--- a/GatewayApp/Frontend/Plantmonitor.Website/src/features/deviceConfiguration/+page.svelte
+++ b/GatewayApp/Frontend/Plantmonitor.Website/src/features/deviceConfiguration/+page.svelte
@@ -78,7 +78,7 @@
 		const cvInterop = new CvInterop();
 		const image = document.getElementById(videoCanvasId) as HTMLImageElement;
 		const videoDisplayFunction = cvInterop.displayVideoBuilder(image);
-		connection.stream('StreamVideo', 4, 100).subscribe({
+		connection.stream('StreamVideo', 1, 100).subscribe({
 			next: async (x) => {
 				frameCounter++;
 				const payload = x as Uint8Array;

--- a/GatewayApp/Frontend/Plantmonitor.Website/src/features/deviceConfiguration/+page.svelte
+++ b/GatewayApp/Frontend/Plantmonitor.Website/src/features/deviceConfiguration/+page.svelte
@@ -9,6 +9,7 @@
 	} from '../../services/GatewayAppApi';
 	import 'typeExtensions';
 	import * as signalR from '@microsoft/signalr';
+	import * as signalRProtocols from '@microsoft/signalr-protocol-msgpack';
 	import { Task } from '~/types/task';
 	import { ImageTakingClient, MotorMovementClient } from '~/services/PlantMonitorControlApi';
 	import { CvInterop } from './CvInterop';
@@ -71,15 +72,18 @@
 		await connection?.stop();
 		connection = new signalR.HubConnectionBuilder()
 			.withUrl(`https://${device}/hub/video`, { withCredentials: false })
+			.withHubProtocol(new signalRProtocols.MessagePackHubProtocol())
 			.build();
 		await connection.start();
 		const cvInterop = new CvInterop();
 		const image = document.getElementById(videoCanvasId) as HTMLImageElement;
 		const videoDisplayFunction = cvInterop.displayVideoBuilder(image);
-		connection.stream('StreamVideo').subscribe({
+		connection.stream('StreamVideo', 4, 100).subscribe({
 			next: async (x) => {
 				frameCounter++;
-				await videoDisplayFunction('data:img/jpeg;base64,' + (x as String));
+				const payload = x as Uint8Array;
+				const blob = new Blob([payload], { type: 'image/jpeg' });
+				await videoDisplayFunction(await blob.asBase64Url());
 			},
 			complete: () => console.log('complete'),
 			error: (x) => console.log(x)

--- a/PlantMonitorControl/Features/ImageTaking/DevelopCameraInterop.cs
+++ b/PlantMonitorControl/Features/ImageTaking/DevelopCameraInterop.cs
@@ -27,7 +27,7 @@ public class DevelopCameraInterop() : ICameraInterop
         throw new NotImplementedException();
     }
 
-    public (Pipe Pipe, Task ProcessTask) VideoStream(int width, int height, int quality)
+    public Task<(Pipe Pipe, Task ProcessTask)> VideoStream(int width, int height, int quality)
     {
         var fs = new FileStream("../TestVideo.mjpeg", FileMode.Open);
         var pipe = new Pipe();
@@ -42,6 +42,6 @@ public class DevelopCameraInterop() : ICameraInterop
                 await Task.Delay(10);
             }
         });
-        return (pipe, task);
+        return Task.FromResult((pipe, task));
     }
 }

--- a/PlantMonitorControl/Features/ImageTaking/DevelopCameraInterop.cs
+++ b/PlantMonitorControl/Features/ImageTaking/DevelopCameraInterop.cs
@@ -27,7 +27,7 @@ public class DevelopCameraInterop() : ICameraInterop
         throw new NotImplementedException();
     }
 
-    public (Pipe Pipe, Task ProcessTask) VideoStream()
+    public (Pipe Pipe, Task ProcessTask) VideoStream(int width, int height, int quality)
     {
         var fs = new FileStream("../TestVideo.mjpeg", FileMode.Open);
         var pipe = new Pipe();

--- a/PlantMonitorControl/Features/ImageTaking/RaspberryCameraInterop.cs
+++ b/PlantMonitorControl/Features/ImageTaking/RaspberryCameraInterop.cs
@@ -19,7 +19,7 @@ public interface ICameraInterop
 
     Task<IResult> CaptureTestImage();
 
-    (Pipe Pipe, Task ProcessTask) VideoStream();
+    (Pipe Pipe, Task ProcessTask) VideoStream(int width, int height, int quality);
 }
 
 public class RaspberryCameraInterop() : ICameraInterop
@@ -44,7 +44,7 @@ public class RaspberryCameraInterop() : ICameraInterop
         return _cameraFound;
     }
 
-    public (Pipe Pipe, Task ProcessTask) VideoStream()
+    public (Pipe Pipe, Task ProcessTask) VideoStream(int width, int height, int quality)
     {
         var info = new ProcessStartInfo("pkill", $"-9 -f {_videoProcessSettings.Filename}");
         new Process() { StartInfo = info }.Start();
@@ -52,8 +52,8 @@ public class RaspberryCameraInterop() : ICameraInterop
         .WithContinuousStreaming()
         .WithVflip()
         .WithHflip()
-        .WithMJPEGVideoOptions(100)
-        .WithResolution(640, 480);
+        .WithMJPEGVideoOptions(quality)
+        .WithResolution(width, height);
         var args = builder.GetArguments();
         var process = new ProcessRunner(_videoProcessSettings);
 

--- a/PlantMonitorControl/Features/ImageTaking/RaspberryCameraInterop.cs
+++ b/PlantMonitorControl/Features/ImageTaking/RaspberryCameraInterop.cs
@@ -19,7 +19,7 @@ public interface ICameraInterop
 
     Task<IResult> CaptureTestImage();
 
-    (Pipe Pipe, Task ProcessTask) VideoStream(int width, int height, int quality);
+    Task<(Pipe Pipe, Task ProcessTask)> VideoStream(int width, int height, int quality);
 }
 
 public class RaspberryCameraInterop() : ICameraInterop
@@ -44,10 +44,11 @@ public class RaspberryCameraInterop() : ICameraInterop
         return _cameraFound;
     }
 
-    public (Pipe Pipe, Task ProcessTask) VideoStream(int width, int height, int quality)
+    public async Task<(Pipe Pipe, Task ProcessTask)> VideoStream(int width, int height, int quality)
     {
         var info = new ProcessStartInfo("pkill", $"-9 -f {_videoProcessSettings.Filename}");
         new Process() { StartInfo = info }.Start();
+        await Task.Delay(500);
         var builder = new CommandOptionsBuilder()
         .WithContinuousStreaming()
         .WithVflip()

--- a/PlantMonitorControl/Features/ImageTaking/StreamingHub.cs
+++ b/PlantMonitorControl/Features/ImageTaking/StreamingHub.cs
@@ -15,12 +15,12 @@ public class StreamingHub([FromKeyedServices(ICameraInterop.VisCamera)] ICameraI
     private const int baseFps = 16;
     private const int resolutionHeight = 216;
 
-    public ChannelReader<byte[]> StreamVideo(CancellationToken token, float resolutionMultiplier, int quality)
+    public async Task<ChannelReader<byte[]>> StreamVideo(CancellationToken token, float resolutionMultiplier, int quality)
     {
         var fps = baseFps / resolutionMultiplier / resolutionMultiplier;
         var timeBetweenImages = 1f / fps * 1000f;
         var channel = Channel.CreateUnbounded<byte[]>();
-        var (pipe, _) = cameraInterop.VideoStream((int)(resolutionWidth * resolutionMultiplier), (int)(resolutionHeight * resolutionMultiplier), quality);
+        var (pipe, _) = await cameraInterop.VideoStream((int)(resolutionWidth * resolutionMultiplier), (int)(resolutionHeight * resolutionMultiplier), quality);
         _ = WriteItemsAsync(channel, pipe.Reader, token, (int)timeBetweenImages);
         return channel.Reader;
     }

--- a/PlantMonitorControl/Features/ImageTaking/StreamingHub.cs
+++ b/PlantMonitorControl/Features/ImageTaking/StreamingHub.cs
@@ -11,16 +11,16 @@ namespace PlantMonitorControl.Features.MotorMovement;
 public class StreamingHub([FromKeyedServices(ICameraInterop.VisCamera)] ICameraInterop cameraInterop, ILogger<StreamingHub> logger) : Hub
 {
     private static readonly byte[] _headerBytes = [255, 216, 255, 224, 0, 16, 74, 70, 73, 70, 0];
-    private const int resolutionWidth = 384;
-    private const int baseFps = 16;
-    private const int resolutionHeight = 216;
+    private const float baseFps = 0.2f;
+    private const int maxWidth = 4600;
+    private const int maxHeight = 2560;
 
-    public async Task<ChannelReader<byte[]>> StreamVideo(CancellationToken token, float resolutionMultiplier, int quality)
+    public async Task<ChannelReader<byte[]>> StreamVideo(CancellationToken token, int resolutionDivider, int quality)
     {
-        var fps = baseFps / resolutionMultiplier / resolutionMultiplier;
+        var fps = baseFps * resolutionDivider * resolutionDivider;
         var timeBetweenImages = 1f / fps * 1000f;
         var channel = Channel.CreateUnbounded<byte[]>();
-        var (pipe, _) = await cameraInterop.VideoStream((int)(resolutionWidth * resolutionMultiplier), (int)(resolutionHeight * resolutionMultiplier), quality);
+        var (pipe, _) = await cameraInterop.VideoStream((int)(maxWidth / resolutionDivider), (int)(maxHeight / resolutionDivider), quality);
         _ = WriteItemsAsync(channel, pipe.Reader, token, (int)timeBetweenImages);
         return channel.Reader;
     }

--- a/PlantMonitorControl/PlantMonitorControl.csproj
+++ b/PlantMonitorControl/PlantMonitorControl.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
 	<PropertyGroup>
 		<TargetFramework>net8.0</TargetFramework>
@@ -8,6 +8,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Iot.Device.Bindings" Version="3.1.0" />
+		<PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="8.0.4" />
 		<PackageReference Include="NSwag.AspNetCore" Version="14.0.3" />
 		<PackageReference Include="NSwag.MSBuild" Version="14.0.3" />
 		<PackageReference Include="Serilog.AspNetCore" Version="8.0.1" />

--- a/PlantMonitorControl/Program.cs
+++ b/PlantMonitorControl/Program.cs
@@ -57,7 +57,7 @@ builder.Services.AddOpenApiDocument(options =>
 });
 
 builder.Services.AddControllers();
-builder.Services.AddSignalR();
+builder.Services.AddSignalR().AddMessagePackProtocol();
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();


### PR DESCRIPTION


### Commit messages for #13

- 2e6c2dd5187dc1b8ab9f07869e1e87ce567cf63b added messagepack compression to signalr to optimize the data sent to the client from the device.
Added additional options to define the quality of the stream and the resolution in sensor increments
- 72bc1a67a2e143095d2f25a96464c231967a450f When killing the current video stream, then the task must be awaited for the other thread to notice the exception and thus aborting the previous signalr connection
- f2198b4400f2e30a599243c9155ca7a8c9713fc3 max resolution with divider 1 does not work and smaller numbers are generally much more ressource intensive. This should be optimized in the future.
Quality is working, but lower quality does not improve performance