### PR TITLE
The certificate must be added in the container aswell.

### DIFF
--- a/Confluence/Dockerfiles/Dockerfile
+++ b/Confluence/Dockerfiles/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:21 as frontend
 RUN apt-get install git
 RUN git clone https://github.com/Machriam/PlantMonitor.git
-WORKDIR "/PlantMonitor"
+WORKDIR "/PlantMonitor/GatewayApp/Frontend/Plantmonitor.Website"
 RUN npm i
 RUN npm run build
 
@@ -11,4 +11,4 @@ WORKDIR "/PlantMonitor/GatewayApp/Backend/Plantmonitor.Server"
 RUN dotnet build -c Release -o ./dist -r linux-x64 --no-self-contained ./Plantmonitor.Server.csproj
 COPY --from=frontend /PlantMonitor/GatewayApp/Frontend/Plantmonitor.Website/build /PlantMonitor/GatewayApp/Backend/Plantmonitor.Server/wwwroot
 
-ENTRYPOINT [ "dotnet", "/PlantMonitor/GatewayApp/Backend/Plantmonitor.Server/dist/Plantmonitor.Server.dll" ]
+ENTRYPOINT [ "/PlantMonitor/Confluence/Dockerfiles/run.sh" ]

--- a/Confluence/Dockerfiles/run.sh
+++ b/Confluence/Dockerfiles/run.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+cp -f /srv/secrets/plantmonitor.crt /usr/local/share/ca-certificates/
+/usr/sbin/update-ca-certificates
+dotnet /PlantMonitor/GatewayApp/Backend/Plantmonitor.Server/dist/Plantmonitor.Server.dll

--- a/Confluence/Setup/SetupGatewayMachine.sh
+++ b/Confluence/Setup/SetupGatewayMachine.sh
@@ -28,6 +28,8 @@ sudo mv ~/plantmonitor.* /srv/secrets
 # Trusting self signed certificate in Chrome
 sudo apt install -y libnss3-tools debconf
 certutil -d ~/.pki/nssdb/ -A -t "TC,," -n "PlantMonitor" -i /srv/secrets/plantmonitor.crt
+sudo cp /srv/secrets/plantmonitor.crt /usr/share/ca-certificates/
+sudo update-ca-certificates
 
 
 cd ../Dockerfiles


### PR DESCRIPTION



### Commit messages for #30

- 1b7afc1f8a6ed3b765b70e8af9235c884aa21a63 The certificate must be added in the container aswell.
The host system is not enough.
Chrome does not use the same certificate storage under debian as curl. This means the certificate has to be installed under 2 places during host setup