### PR TITLE
Streaming to a folder on the device, before sending via WLAN

### DIFF
--- a/GatewayApp/Frontend/Plantmonitor.Website/src/services/DeviceStreaming.ts
+++ b/GatewayApp/Frontend/Plantmonitor.Website/src/services/DeviceStreaming.ts
@@ -17,14 +17,15 @@ export class DeviceStreaming {
             .build();
         return {
             connection: connection,
-            start: async (callback: (step: number, image: string) => Promise<void>) => {
+            start: async (callback: (step: number, image: string, date: Date) => Promise<void>) => {
                 await connection.start();
                 connection.stream("StreamPictures", sizeDivider, 100, focusInMeter, device, storeData).subscribe({
                     next: async (x) => {
                         const payload = x as Uint8Array;
-                        const blob = new Blob([payload.subarray(4)], { type: "image/jpeg" });
+                        const blob = new Blob([payload.subarray(12)], { type: "image/jpeg" });
+                        const date = payload.subarray(4, 8).toInt64().fromTicksToDate();
                         const imageUrl = await blob.asBase64Url();
-                        await callback(payload.subarray(0, 4).toInt32(), imageUrl);
+                        await callback(payload.subarray(0, 4).toInt32(), imageUrl, date);
                     },
                     complete: () => console.log("complete"),
                     error: (x) => console.log(x)

--- a/GatewayApp/Frontend/Plantmonitor.Website/src/tests/typeExtensions.spec.ts
+++ b/GatewayApp/Frontend/Plantmonitor.Website/src/tests/typeExtensions.spec.ts
@@ -6,6 +6,12 @@ class Test {
 		this.Number = number;
 	}
 }
+describe("Uint8Array to Int64 should work", () => {
+	test("with negative integers", () => {
+		const data = new Uint8Array([129, 65, 230, 205, 122, 107, 220, 8]);
+		expect(data.toInt64()).equal(638503422364369281n);
+	});
+});
 
 describe("Uint8Array to Int32 should work", () => {
 	test("with negative integers", () => {
@@ -27,6 +33,14 @@ describe("Uint8Array to Int32 should work", () => {
 	test("with positive integers", () => {
 		const data = new Uint8Array([139, 164, 0, 0]);
 		expect(data.toInt32()).equal(42123);
+	});
+});
+describe("ticksToDate should work", () => {
+	test("default", () => {
+		const ticks = BigInt(638503422364369281n);
+		const expected = new Date("2024-05-03T14:10:36.436Z")
+		const result = ticks.fromTicksToDate();
+		expect(result.getTime()).equal(expected.getTime());
 	});
 });
 

--- a/GatewayApp/Frontend/Plantmonitor.Website/src/types/typeExtensions.d.ts
+++ b/GatewayApp/Frontend/Plantmonitor.Website/src/types/typeExtensions.d.ts
@@ -9,6 +9,9 @@ interface String {
 interface Array<T> {
 	mean(selector: (x: T) => number): number;
 }
+interface BigInt {
+	fromTicksToDate(): Date;
+}
 interface Number {
 	roundTo(decimalPlaces: number): number;
 	isSuccessStatusCode(): boolean;
@@ -18,10 +21,15 @@ interface Blob {
 }
 interface Uint8Array {
 	toInt32(): number;
+	toInt64(): bigint;
 }
 
 Uint8Array.prototype.toInt32 = function (this: Uint8Array): number {
 	return new DataView(this.slice(0, 4).buffer).getInt32(0, true);
+}
+
+Uint8Array.prototype.toInt64 = function (this: Uint8Array): bigint {
+	return new DataView(this.slice(0, 8).buffer).getBigInt64(0, true);
 }
 
 Array.prototype.mean = function (this: Array<T>, selector: (x: T) => number) {
@@ -31,6 +39,12 @@ Array.prototype.mean = function (this: Array<T>, selector: (x: T) => number) {
 
 Number.prototype.roundTo = function (this: number, decimalPlaces: number): number {
 	return +this.toFixed(decimalPlaces);
+}
+BigInt.prototype.fromTicksToDate = function (this: bigint): Date {
+	const zeroTime = BigInt(new Date("0001-01-01T00:00:00Z").getTime());
+	const tickDivider = BigInt(10000);
+	const milliseconds = Number(this / tickDivider + zeroTime);
+	return new Date(milliseconds);
 }
 Number.prototype.isSuccessStatusCode = function (this: number): boolean {
 	return this == 200 || this == 204;

--- a/PlantMonitorControl/Features/ImageTaking/StreamingHub.cs
+++ b/PlantMonitorControl/Features/ImageTaking/StreamingHub.cs
@@ -6,7 +6,42 @@ namespace PlantMonitorControl.Features.MotorMovement;
 
 public class StreamingHub([FromKeyedServices(ICameraInterop.VisCamera)] ICameraInterop cameraInterop, ILogger<StreamingHub> logger, IMotorPositionCalculator motorPosition) : Hub
 {
-    private static readonly byte[] _headerBytes = [255, 216, 255, 224, 0, 16, 74, 70, 73, 70, 0];
+    private static readonly byte[] s_headerBytes = [255, 216, 255, 224, 0, 16, 74, 70, 73, 70, 0];
+    private static readonly string s_tempImagePath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "tempImages");
+
+    public async Task<ChannelReader<byte[]>> StreamStoredMjpeg(float resolutionDivider, int quality, float distanceInM, string sessionId, CancellationToken token)
+    {
+        Directory.Delete(s_tempImagePath, true);
+        var storagePath = Path.Combine(s_tempImagePath, sessionId);
+        Directory.CreateDirectory(storagePath);
+        var counter = 0;
+        var channel = Channel.CreateBounded<byte[]>(new BoundedChannelOptions(1)
+        {
+            AllowSynchronousContinuations = false,
+            FullMode = BoundedChannelFullMode.DropWrite,
+            SingleReader = true,
+            SingleWriter = true,
+        });
+        var (pipe, _) = await cameraInterop.MjpegStream(resolutionDivider, quality, distanceInM);
+        _ = WriteItemsAsync(async (b, t) => await File.WriteAllBytesAsync(Path.Combine(s_tempImagePath, $"{counter++}.data"), b, t), pipe.Reader, token);
+        _ = ReadImagesFromFiles(channel, storagePath, token);
+        return channel.Reader;
+    }
+
+    private static async Task ReadImagesFromFiles(Channel<byte[]> channel, string imagePath, CancellationToken token)
+    {
+        var counter = 0;
+        while (true)
+        {
+            await Task.Delay(10, token);
+            var currentPath = Path.Combine(imagePath, $"{counter}.data");
+            if (!Path.Exists(currentPath)) continue;
+            var bytesToSend = await File.ReadAllBytesAsync(currentPath, token);
+            await channel.Writer.WriteAsync(bytesToSend, token);
+            File.Delete(currentPath);
+            counter++;
+        }
+    }
 
     public async Task<ChannelReader<byte[]>> StreamMjpeg(float resolutionDivider, int quality, float distanceInM, CancellationToken token)
     {
@@ -18,7 +53,7 @@ public class StreamingHub([FromKeyedServices(ICameraInterop.VisCamera)] ICameraI
             SingleWriter = true,
         });
         var (pipe, _) = await cameraInterop.MjpegStream(resolutionDivider, quality, distanceInM);
-        _ = WriteItemsAsync(channel, pipe.Reader, token);
+        _ = WriteItemsAsync(async (b, t) => await channel.Writer.WriteAsync(b, t), pipe.Reader, token);
         return channel.Reader;
     }
 
@@ -27,15 +62,15 @@ public class StreamingHub([FromKeyedServices(ICameraInterop.VisCamera)] ICameraI
         var headerIndex = 0;
         return currentByte =>
         {
-            if (currentByte == _headerBytes[headerIndex]) headerIndex++;
+            if (currentByte == s_headerBytes[headerIndex]) headerIndex++;
             else headerIndex = 0;
-            var headerFound = headerIndex == _headerBytes.Length;
+            var headerFound = headerIndex == s_headerBytes.Length;
             if (headerFound) headerIndex = 0;
             return headerFound;
         };
     }
 
-    private async Task WriteItemsAsync(ChannelWriter<byte[]> writer, PipeReader reader, CancellationToken token)
+    private async Task WriteItemsAsync(Func<byte[], CancellationToken, Task> writeFunction, PipeReader reader, CancellationToken token)
     {
         try
         {
@@ -52,20 +87,22 @@ public class StreamingHub([FromKeyedServices(ICameraInterop.VisCamera)] ICameraI
                     {
                         imageBuffer[imageIndex++] = buff.Span[i];
                         if (!headerFinder(buff.Span[i])) continue;
-                        var sendBuffer = imageBuffer[0..(imageIndex - _headerBytes.Length)];
+                        var sendBuffer = imageBuffer[0..(imageIndex - s_headerBytes.Length)];
                         imageIndex = 0;
                         if (imageStarted)
                         {
-                            await writer.WriteAsync(sendBuffer, token);
-                            for (var j = 0; j < _headerBytes.Length; j++) imageBuffer[imageIndex++] = _headerBytes[j];
+                            await writeFunction(sendBuffer, token);
+                            for (var j = 0; j < s_headerBytes.Length; j++) imageBuffer[imageIndex++] = s_headerBytes[j];
                             imageStarted = false;
                             break;
                         }
                         else
                         {
                             var positionBytes = BitConverter.GetBytes(motorPosition.CurrentPosition());
+                            var timestamp = BitConverter.GetBytes(DateTime.Now.ToUniversalTime().Ticks);
                             for (var j = 0; j < positionBytes.Length; j++) imageBuffer[imageIndex++] = positionBytes[j];
-                            for (var j = 0; j < _headerBytes.Length; j++) imageBuffer[imageIndex++] = _headerBytes[j];
+                            for (var j = 0; j < timestamp.Length; j++) imageBuffer[imageIndex++] = timestamp[j];
+                            for (var j = 0; j < s_headerBytes.Length; j++) imageBuffer[imageIndex++] = s_headerBytes[j];
                             imageStarted = true;
                         }
                     }


### PR DESCRIPTION


### Commit messages for #43

- bb5a96bee77583265b1e023f982b021ea2e26248 The device stores now the read image data to disk and then serves the disk images one after another to the gateway server.
No frames are dropped this way and a flaky connection can still send the image data.
The current date of the images is stored inside the byte array as ticks. This means the first 4 bytes are the step position and the second 8 bytes the ticks when the image was read. With the 12th byte, the picture begins