### PR TITLE
Simple Host header comparison

### DIFF
--- a/GatewayApp/Backend/Plantmonitor.Server/Features/DeviceControl/MotorAccessFilter.cs
+++ b/GatewayApp/Backend/Plantmonitor.Server/Features/DeviceControl/MotorAccessFilter.cs
@@ -7,10 +7,8 @@ public class MotorAccessFilter : ActionFilterAttribute
 {
     public override void OnActionExecuting(ActionExecutingContext context)
     {
-        var remoteIp = context.HttpContext.Connection.RemoteIpAddress?.ToString();
-        var localIp = context.HttpContext.Connection.LocalIpAddress?.ToString();
-        Log.Logger.Information("Ip {ip} accessed motor", remoteIp);
-        if (!new[] { "127.0.0.1", "::1", localIp }.Contains(remoteIp))
-            throw new Exception("Motor movement actions are only allowed on the gateway computer");
+        var hostIp = context.HttpContext.Request.Headers.Host;
+        Log.Logger.Information("Ip {ip} accessed motor", hostIp.Select(h => h).AsJson());
+        if (hostIp.Count != 1 || hostIp[0]?.Split(":")[0] != "localhost") throw new Exception("Motor movement actions are only allowed on the gateway computer");
     }
 }


### PR DESCRIPTION


### Commit messages for #64

- 8a738bc5ebb01899cb4f89d473cadd4016b1ea21 Reverting previous changes. Only a simple check for the http header is now done.
This is by no means secure, but it should fix the problem of moving the arm without thinking about consequences like cutting connections or destroying the cameras.
- b7fae8f03ead78f4640894168d8466ad78dab9b0 Merge