### PR TITLE
Fixes for automatic photo touring

### DIFF
--- a/GatewayApp/Backend/Plantmonitor.Server/Features/AutomaticPhototour/AutomaticPhotoTourWorker.cs
+++ b/GatewayApp/Backend/Plantmonitor.Server/Features/AutomaticPhototour/AutomaticPhotoTourWorker.cs
@@ -142,14 +142,18 @@ public class AutomaticPhotoTourWorker(IServiceScopeFactory serviceProvider) : IH
              x => irFolder = x, x => DataReceived(x, CameraType.IR), CancellationToken.None).RunInBackground(ex =>
              {
                  ex.LogError();
-                 logger("Ir streaming error: " + ex.Message, PhotoTourEventType.Error);
+                 using var scope = serviceProvider.CreateScope();
+                 using var dataContext = scope.ServiceProvider.GetRequiredService<IDataContext>();
+                 dataContext.CreatePhotoTourEventLogger(photoTourId)("Ir streaming error: " + ex.Message, PhotoTourEventType.Error);
              });
         visStreamer.StartStreamingToDisc(device.Ip, device.Health.DeviceId ?? "", CameraType.Vis.GetAttributeOfType<CameraTypeInfo>(),
              StreamingMetaData.Create(1, 100, movementPlan.MovementPlan.StepPoints.FirstOrDefault().FocusInCentimeter, true, [.. pointsToReach], CameraType.Vis),
              x => visFolder = x, x => DataReceived(x, CameraType.Vis), CancellationToken.None).RunInBackground(ex =>
              {
                  ex.LogError();
-                 logger("Vis streaming error: " + ex.Message, PhotoTourEventType.Error);
+                 using var scope = serviceProvider.CreateScope();
+                 using var dataContext = scope.ServiceProvider.GetRequiredService<IDataContext>();
+                 dataContext.CreatePhotoTourEventLogger(photoTourId)("Vis streaming error: " + ex.Message, PhotoTourEventType.Error);
              });
         foreach (var step in movementPlan.MovementPlan.StepPoints)
         {

--- a/GatewayApp/Backend/Plantmonitor.Server/Features/AutomaticPhototour/PictureDiskStreamer.cs
+++ b/GatewayApp/Backend/Plantmonitor.Server/Features/AutomaticPhototour/PictureDiskStreamer.cs
@@ -5,7 +5,7 @@ using System.Diagnostics;
 
 namespace Plantmonitor.Server.Features.AutomaticPhotoTour;
 
-public interface IPictureDiskStreamer : IAsyncDisposable
+public interface IPictureDiskStreamer : IAsyncDisposable, IDisposable
 {
     Task StartStreamingToDisc(string ip, string deviceId, CameraTypeInfo cameraType, StreamingMetaData data, Action<string> picturePathCallback,
             Func<CameraStreamFormatter, Task> imageReceivedCallback, CancellationToken token);
@@ -85,5 +85,12 @@ public class PictureDiskStreamer(IEnvironmentConfiguration configuration) : IPic
         if (_connection == null) return ValueTask.CompletedTask;
         _connection.Closed -= Connection_Closed;
         return _connection.DisposeAsync();
+    }
+
+    public void Dispose()
+    {
+        if (_connection == null) return;
+        _connection.Closed -= Connection_Closed;
+        _ = _connection.DisposeAsync();
     }
 }

--- a/GatewayApp/Backend/Plantmonitor.Server/Program.cs
+++ b/GatewayApp/Backend/Plantmonitor.Server/Program.cs
@@ -14,6 +14,7 @@ using Serilog;
 var builder = WebApplication.CreateBuilder(args);
 Log.Logger = new LoggerConfiguration()
     .WriteTo.Console()
+    .MinimumLevel.Override("Microsoft.EntityFrameworkCore.Database.Command", Serilog.Events.LogEventLevel.Warning)
     .CreateLogger();
 
 Log.Information("Starting Gatewayserver");

--- a/GatewayApp/Frontend/Plantmonitor.Website/src/services/healthStateExtensions.ts
+++ b/GatewayApp/Frontend/Plantmonitor.Website/src/services/healthStateExtensions.ts
@@ -1,4 +1,4 @@
-import { HealthState } from "./GatewayAppApi";
+import {HealthState} from "./GatewayAppApi";
 
 export function formatHealthState(state: HealthState) {
     const flagCount = (Object.getOwnPropertyNames(HealthState).length / 2) - 1;
@@ -8,4 +8,10 @@ export function formatHealthState(state: HealthState) {
     }
     if (result.length == 0) return [HealthState[HealthState.NA]];
     return result;
+}
+
+export function hasFlag(state: HealthState | undefined, flagState: HealthState) {
+    if (state == undefined) return false;
+    return !!(state & flagState);
+
 }


### PR DESCRIPTION


### Commit messages for #115

- 3f6efd4b95332c476e7beb986e5584fc95cd71dd No Datacontext logs, as they are just to much.
Creating a new scope, when throwing an error, as the old scope might be already disposed.
Implemented IDisposable aswell as fallback.
1000 mintime, 4000 maxtime and 400 ramp feel pretty smooth for motor movement