### PR TITLE
Fix of wrong cropping of vis images

### DIFF
--- a/GatewayApp/Backend/Plantmonitor.Server.Tests/Features/ImageStitching/ImageCropperTests.cs
+++ b/GatewayApp/Backend/Plantmonitor.Server.Tests/Features/ImageStitching/ImageCropperTests.cs
@@ -65,6 +65,19 @@ public class ImageCropperTests
     }
 
     [Fact]
+    public void CropImage_ShouldNotRunForever_ShouldWork()
+    {
+        var sut = CreateImageCropper();
+        var applicationPath = Directory.GetCurrentDirectory().GetApplicationRootGitPath();
+        var imageFile = $"{applicationPath}/PlantMonitorControl.Tests/TestData/CropTest/Plants.png";
+        var result = sut.CropImages(imageFile, "", s_singlePlantBottomMiddlePolygon, new(0, 0), 960);
+        result.VisImage.ShowImage("CroppedImage");
+        result.VisImage.Cols.Should().Be(215);
+        result.VisImage.Rows.Should().Be(243);
+        result.VisImage.Dispose();
+    }
+
+    [Fact]
     public void CropImage_WithOffset_ShouldWork()
     {
         var sut = CreateImageCropper();

--- a/GatewayApp/Backend/Plantmonitor.Server.Tests/Features/ImageStitching/ImageCropperTests.cs
+++ b/GatewayApp/Backend/Plantmonitor.Server.Tests/Features/ImageStitching/ImageCropperTests.cs
@@ -113,7 +113,7 @@ public class ImageCropperTests
         var resultMat = sut.CreateRawIr(irMat);
         var resizeMat = resultMat.Clone();
         sut.Resize(resizeMat, 640);
-        resizeMat.ShowImage("CroppedIR");
+        resizeMat.ShowImage("CroppedIR", 100);
         resultMat.Dispose();
         resizeMat.Dispose();
         irMat.Dispose();


### PR DESCRIPTION


### Commit messages for #146

- 4877a9538224b086ca1f7e21e69aee4320160452 another guard to sanity check the results of the opencv operations. I really do not know why, but Emgu or OpenCV has massive timing issues.
When sleeping for a period those errors vanish.
When executing only one test at a time, those errors are not existent. Only when multiple tests are run in parallel, then the issue can be reproduced.

### Commit messages for #146

- 4877a9538224b086ca1f7e21e69aee4320160452 another guard to sanity check the results of the opencv operations. I really do not know why, but Emgu or OpenCV has massive timing issues.
When sleeping for a period those errors vanish.
When executing only one test at a time, those errors are not existent. Only when multiple tests are run in parallel, then the issue can be reproduced.
- 2e42d43b1e91bc669e2603d09a5acdbedd060381 this seems to fix the issue, that under linux in a docker container the cropping of vis images does not work all the time.
In OpenCV new Mats are allocated with heap data and only with a SetTo command, those Mats are actually initialized. Furthermore a mask should only have 1 channel. So I use another Mat as a mask

### Commit messages for #146

- 4877a9538224b086ca1f7e21e69aee4320160452 another guard to sanity check the results of the opencv operations. I really do not know why, but Emgu or OpenCV has massive timing issues.
When sleeping for a period those errors vanish.
When executing only one test at a time, those errors are not existent. Only when multiple tests are run in parallel, then the issue can be reproduced.
- 2e42d43b1e91bc669e2603d09a5acdbedd060381 this seems to fix the issue, that under linux in a docker container the cropping of vis images does not work all the time.
In OpenCV new Mats are allocated with heap data and only with a SetTo command, those Mats are actually initialized. Furthermore a mask should only have 1 channel. So I use another Mat as a mask
- 32504937affae1dbdb8bcc41853230ac87b9b81f Setting the values explicitly in the data matrix seems to always work. This means retrying is no longer necessary