### PR TITLE
Usability Fixes

### DIFF
--- a/GatewayApp/Backend/Plantmonitor.Server.Tests/Features/ImageStitching/PhotoStitcherTests.cs
+++ b/GatewayApp/Backend/Plantmonitor.Server.Tests/Features/ImageStitching/PhotoStitcherTests.cs
@@ -76,7 +76,7 @@ public class PhotoStitcherTests
             Name = "Name",
             VisImage = i % 2 == 0 ? result1.VisImage.Clone() : result2.VisImage.Clone(),
         });
-        var result = sut.CreateVirtualImage(images, 300, 300, 20);
+        var result = sut.CreateVirtualImage(images, 300, 300);
         result.VisImage.ShowImage("VirtualVis", 0);
         result.IrColorImage.ShowImage("VirtualIr", 0);
         result.IrRawData.ShowImage("VirtualRaw");

--- a/GatewayApp/Backend/Plantmonitor.Server.Tests/Features/ImageStitching/VirtualImageWorkerTests.cs
+++ b/GatewayApp/Backend/Plantmonitor.Server.Tests/Features/ImageStitching/VirtualImageWorkerTests.cs
@@ -32,7 +32,7 @@ public class VirtualImageWorkerTests
     }
 
     [Fact]
-    public void RunImageCreation_NegativeIrHeight_ShouldWork()
+    public void RunImageCreation_NegativeBounds_ShouldWork()
     {
         var sut = CreateVirtualImageWorker();
         var dataContext = Substitute.For<IDataContext>();
@@ -40,10 +40,10 @@ public class VirtualImageWorkerTests
         var cropper = new ImageCropper();
         var configuration = Substitute.For<IEnvironmentConfiguration>();
         var applicationPath = Directory.GetCurrentDirectory().GetApplicationRootGitPath();
-        var irFolder = $"{applicationPath}/PlantMonitorControl.Tests/TestData/VirtualImageTest2/IrData";
-        var visFolder = $"{applicationPath}/PlantMonitorControl.Tests/TestData/VirtualImageTest2/VisData";
-        var testData = $"{applicationPath}/PlantMonitorControl.Tests/TestData/VirtualImageTest2/TestData";
-        var result = $"{applicationPath}/PlantMonitorControl.Tests/TestData/VirtualImageTest2/Result";
+        var irFolder = $"{applicationPath}/PlantMonitorControl.Tests/TestData/VirtualImageTest_NegativeBounds/IrData";
+        var visFolder = $"{applicationPath}/PlantMonitorControl.Tests/TestData/VirtualImageTest_NegativeBounds/VisData";
+        var testData = $"{applicationPath}/PlantMonitorControl.Tests/TestData/VirtualImageTest_NegativeBounds/TestData";
+        var result = $"{applicationPath}/PlantMonitorControl.Tests/TestData/VirtualImageTest_NegativeBounds/Result";
         dataContext.PhotoTourTrips.ReturnsForAnyArgs(new QueryableList<PhotoTourTrip>() { new PhotoTourTrip() {
             Id=1,
             PhotoTourFk=1,

--- a/GatewayApp/Backend/Plantmonitor.Server.Tests/Features/ImageStitching/VirtualImageWorkerTests.cs
+++ b/GatewayApp/Backend/Plantmonitor.Server.Tests/Features/ImageStitching/VirtualImageWorkerTests.cs
@@ -32,6 +32,38 @@ public class VirtualImageWorkerTests
     }
 
     [Fact]
+    public void RunImageCreation_NegativeIrHeight_ShouldWork()
+    {
+        var sut = CreateVirtualImageWorker();
+        var dataContext = Substitute.For<IDataContext>();
+        var stitcher = new PhotoStitcher();
+        var cropper = new ImageCropper();
+        var configuration = Substitute.For<IEnvironmentConfiguration>();
+        var applicationPath = Directory.GetCurrentDirectory().GetApplicationRootGitPath();
+        var irFolder = $"{applicationPath}/PlantMonitorControl.Tests/TestData/VirtualImageTest2/IrData";
+        var visFolder = $"{applicationPath}/PlantMonitorControl.Tests/TestData/VirtualImageTest2/VisData";
+        var testData = $"{applicationPath}/PlantMonitorControl.Tests/TestData/VirtualImageTest2/TestData";
+        var result = $"{applicationPath}/PlantMonitorControl.Tests/TestData/VirtualImageTest2/Result";
+        dataContext.PhotoTourTrips.ReturnsForAnyArgs(new QueryableList<PhotoTourTrip>() { new PhotoTourTrip() {
+            Id=1,
+            PhotoTourFk=1,
+            IrDataFolder=irFolder,
+            VisDataFolder=visFolder,
+            Timestamp=DateTime.Now,
+            PhotoTourFkNavigation=new AutomaticPhotoTour(){Name="Test"}
+        } });
+        var extractionTemplates = File.ReadAllText($"{testData}/ExtractionTemplate.json")
+            .FromJson<QueryableList<PlantExtractionTemplate>>() ?? [];
+        var plants = File.ReadAllText($"{testData}/Plants.json").FromJson<QueryableList<PhotoTourPlant>>() ?? [];
+        foreach (var template in extractionTemplates) template.PhotoTripFkNavigation = new PhotoTourTrip() { PhotoTourFk = 1, Timestamp = DateTime.Now.AddYears(-1) };
+        foreach (var plant in plants) plant.PhotoTourFk = 1;
+        dataContext.PlantExtractionTemplates.ReturnsForAnyArgs(extractionTemplates);
+        dataContext.PhotoTourPlants.ReturnsForAnyArgs(plants);
+        configuration.VirtualImagePath("", 0).ReturnsForAnyArgs(result);
+        sut.RunImageCreation(dataContext, stitcher, cropper, configuration);
+    }
+
+    [Fact]
     public void RunImageCreation_ShouldWork()
     {
         var sut = CreateVirtualImageWorker();

--- a/GatewayApp/Backend/Plantmonitor.Server/Features/AppConfiguration/ApiExceptionFilter.cs
+++ b/GatewayApp/Backend/Plantmonitor.Server/Features/AppConfiguration/ApiExceptionFilter.cs
@@ -1,0 +1,37 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.EntityFrameworkCore;
+
+namespace Plantmonitor.Server.Features.AppConfiguration
+{
+    public class ApiExceptionFilter(ILogger<ApiExceptionFilter> logger) : ExceptionFilterAttribute
+    {
+        public override void OnException(ExceptionContext context)
+        {
+            switch (context.Exception)
+            {
+                case DbUpdateException:
+                    if (context.Exception.InnerException?.Message.Contains("duplicate key", StringComparison.OrdinalIgnoreCase) == true)
+                    {
+                        context.Result = new JsonResult("The unique identifier of this entry is already Taken") { StatusCode = StatusCodes.Status500InternalServerError };
+                        break;
+                    }
+                    if (context.Exception.InnerException?.Message.Contains("foreign key", StringComparison.OrdinalIgnoreCase) == true)
+                    {
+                        context.Result = new JsonResult("Other database entries reference this entry. Those links must be deleted first") { StatusCode = StatusCodes.Status500InternalServerError };
+                        break;
+                    }
+                    context.Result = new JsonResult(context.Exception.Message) { StatusCode = StatusCodes.Status500InternalServerError };
+                    break;
+
+                default:
+                    context.Result = new JsonResult(context.Exception.Message) { StatusCode = StatusCodes.Status500InternalServerError };
+                    break;
+            }
+            logger.Log(LogLevel.Error, "Message: {message}", context.Exception.Message);
+            logger.Log(LogLevel.Error, "InnerMessage: {message}", context.Exception.InnerException?.Message);
+            logger.Log(LogLevel.Error, "Stacktrace: {trace}", context.Exception.StackTrace);
+            base.OnException(context);
+        }
+    }
+}

--- a/GatewayApp/Backend/Plantmonitor.Server/Features/AppConfiguration/Const.cs
+++ b/GatewayApp/Backend/Plantmonitor.Server/Features/AppConfiguration/Const.cs
@@ -1,0 +1,7 @@
+﻿namespace Plantmonitor.Server.Features.AppConfiguration;
+
+public static class Const
+{
+    public const float IrScalingHeight = 480f;
+    public const float IrScalingWidth = 640f;
+}

--- a/GatewayApp/Backend/Plantmonitor.Server/Features/ImageStitching/ImageCropper.cs
+++ b/GatewayApp/Backend/Plantmonitor.Server/Features/ImageStitching/ImageCropper.cs
@@ -6,6 +6,7 @@ using Emgu.CV.Structure;
 using Plantmonitor.Shared.Features.ImageStreaming;
 using Serilog;
 using Emgu.CV.CvEnum;
+using Plantmonitor.Server.Features.AppConfiguration;
 
 namespace Plantmonitor.Server.Features.ImageStitching;
 
@@ -119,10 +120,9 @@ public class ImageCropper() : IImageCropper
     public (Mat VisImage, Mat? IrImage) CropImages(string visImage, string? irImage, NpgsqlPoint[] visPolygon, NpgsqlPoint irOffset, int scalingHeightInPx)
     {
         var visMat = MatFromFile(visImage, out _);
-        const float DefaultOffsetHeight = 480f;
         var resizeRatio = scalingHeightInPx / (double)visMat.Height;
         visPolygon = visPolygon.Select(vp => new NpgsqlPoint(vp.X * resizeRatio, vp.Y * resizeRatio)).ToArray();
-        irOffset = new NpgsqlPoint(-irOffset.X * scalingHeightInPx / DefaultOffsetHeight, -irOffset.Y * scalingHeightInPx / DefaultOffsetHeight);
+        irOffset = new NpgsqlPoint(-irOffset.X * scalingHeightInPx / Const.IrScalingHeight, -irOffset.Y * scalingHeightInPx / Const.IrScalingHeight);
         Resize(visMat, scalingHeightInPx);
         var visCrop = CutImage(visPolygon, visMat);
         if (irImage.IsEmpty())

--- a/GatewayApp/Backend/Plantmonitor.Server/Features/ImageStitching/ImageCropper.cs
+++ b/GatewayApp/Backend/Plantmonitor.Server/Features/ImageStitching/ImageCropper.cs
@@ -143,16 +143,20 @@ public class ImageCropper() : IImageCropper
 
     private static Mat CutIrImage(NpgsqlPoint[] polygon, Mat mat)
     {
-        var roi = CalculateSafeRoi(polygon, mat);
+        var roi = CalculateInboundRoi(polygon, mat);
         return new Mat(mat, roi);
     }
 
-    private static Rectangle CalculateSafeRoi(NpgsqlPoint[] polygon, Mat mat)
+    private static Rectangle CalculateInboundRoi(NpgsqlPoint[] polygon, Mat mat)
     {
-        var minX = Math.Min(mat.Cols, Math.Max(0, polygon.Min(p => p.X)));
-        var minY = Math.Min(mat.Rows, Math.Max(0, polygon.Min(p => p.Y)));
-        var width = Math.Min(mat.Cols, polygon.Max(p => p.X)) - minX;
-        var height = Math.Min(mat.Rows, polygon.Max(p => p.Y)) - minY;
+        var minPolygonX = Math.Max(0, polygon.Min(p => p.X));
+        var minPolygonY = Math.Max(0, polygon.Min(p => p.Y));
+        var maxPolygonX = Math.Max(0, polygon.Max(p => p.X));
+        var maxPolygonY = Math.Max(0, polygon.Max(p => p.Y));
+        var minX = Math.Min(mat.Cols, minPolygonX);
+        var minY = Math.Min(mat.Rows, minPolygonY);
+        var width = Math.Min(mat.Cols, maxPolygonX) - minX;
+        var height = Math.Min(mat.Rows, maxPolygonY) - minY;
         return new Rectangle((int)minX, (int)minY, (int)width, (int)height);
     }
 
@@ -165,7 +169,7 @@ public class ImageCropper() : IImageCropper
 
     private static Mat CutImage(NpgsqlPoint[] polygon, Mat mat)
     {
-        var roi = CalculateSafeRoi(polygon, mat);
+        var roi = CalculateInboundRoi(polygon, mat);
         var polygonCrop = new Mat(mat.Rows, mat.Cols, mat.Depth, mat.NumberOfChannels);
         var mask = new Mat(mat.Rows, mat.Cols, DepthType.Cv8U, 1);
         polygonCrop.SetTo(new MCvScalar(0, 0, 0));

--- a/GatewayApp/Backend/Plantmonitor.Server/Features/ImageStitching/VirtualImageWorker.cs
+++ b/GatewayApp/Backend/Plantmonitor.Server/Features/ImageStitching/VirtualImageWorker.cs
@@ -132,7 +132,7 @@ public class VirtualImageWorker(IServiceScopeFactory scopeFactory, IEnvironmentC
                 virtualImageList[^1].ColoredIrImage = colorMat;
             }
             logger.LogInformation("Stitching virtual image together");
-            var virtualImage = stitcher.CreateVirtualImage(virtualImageList, (int)maxBoundingBoxWidth, (int)maxBoundingBoxHeight, 50);
+            var virtualImage = stitcher.CreateVirtualImage(virtualImageList, (int)maxBoundingBoxWidth, (int)maxBoundingBoxHeight, 10);
             var fullMetaDataTable = AddAditionalMetaData(dataContext, tripToProcess, virtualImageList, virtualImage);
 
             var fileBaseName = Path.GetFileNameWithoutExtension(virtualImageFile);

--- a/GatewayApp/Backend/Plantmonitor.Server/Features/ImageStitching/VirtualImageWorker.cs
+++ b/GatewayApp/Backend/Plantmonitor.Server/Features/ImageStitching/VirtualImageWorker.cs
@@ -91,7 +91,11 @@ public class VirtualImageWorker(IServiceScopeFactory scopeFactory, IEnvironmentC
             var virtualImageFile = $"{virtualImageFolder}/trip_{image.Timestamp:yyyyMMdd_HHmmss_fff}.zip";
             logger.LogInformation("Processing virtual image {image} of tour {tour}", virtualImageFile, tripToProcess.PhotoTourFkNavigation.Name);
             var virtualImageList = new List<PhotoStitcher.PhotoStitchData>();
-            foreach (var plant in plantsOfTour.OrderBy(pot => pot.Name).ThenBy(pot => pot.Id))
+            foreach (var plant in plantsOfTour
+                .Select(pot => (Number: pot.Name.ExtractNumbersFromString(out var cleanText), CleanText: cleanText, Plant: pot))
+                .OrderBy(pot => pot.CleanText)
+                .ThenBy(pot => pot.Number)
+                .Select(pot => pot.Plant))
             {
                 logger.LogInformation("Adding plant {plant} to virtual image {image}", $"{plant.Name} {plant.Comment}", virtualImageFile);
                 var extractionTemplate = extractionTemplates

--- a/GatewayApp/Backend/Plantmonitor.Server/Features/ImageStitching/VirtualImageWorker.cs
+++ b/GatewayApp/Backend/Plantmonitor.Server/Features/ImageStitching/VirtualImageWorker.cs
@@ -78,8 +78,8 @@ public class VirtualImageWorker(IServiceScopeFactory scopeFactory, IEnvironmentC
             logger.LogWarning("No extraction templates defined for tour {tour}. Exiting", tripToProcess.PhotoTourFkNavigation.Name);
             return;
         }
-        var maxBoundingBoxHeight = extractionTemplates.Max(bb => bb.BoundingBoxHeight);
-        var maxBoundingBoxWidth = extractionTemplates.Max(bb => bb.BoundingBoxWidth);
+        var maxBoundingBoxHeight = (int)float.Ceiling(extractionTemplates.Max(bb => bb.BoundingBoxHeight));
+        var maxBoundingBoxWidth = (int)float.Ceiling(extractionTemplates.Max(bb => bb.BoundingBoxWidth));
         var imagesToCreate = dataContext.PhotoTourTrips
             .Where(ptt => ptt.VirtualPicturePath == null && ptt.PhotoTourFk == tripToProcess.PhotoTourFk)
             .ToList();
@@ -132,7 +132,7 @@ public class VirtualImageWorker(IServiceScopeFactory scopeFactory, IEnvironmentC
                 virtualImageList[^1].ColoredIrImage = colorMat;
             }
             logger.LogInformation("Stitching virtual image together");
-            var virtualImage = stitcher.CreateVirtualImage(virtualImageList, (int)maxBoundingBoxWidth, (int)maxBoundingBoxHeight, 10);
+            var virtualImage = stitcher.CreateVirtualImage(virtualImageList, maxBoundingBoxWidth, maxBoundingBoxHeight);
             var fullMetaDataTable = AddAditionalMetaData(dataContext, tripToProcess, virtualImageList, virtualImage);
 
             var fileBaseName = Path.GetFileNameWithoutExtension(virtualImageFile);

--- a/GatewayApp/Backend/Plantmonitor.Server/Program.cs
+++ b/GatewayApp/Backend/Plantmonitor.Server/Program.cs
@@ -85,6 +85,7 @@ builder.Services.AddOpenApiDocument(options =>
 builder.Services.AddMvc(options =>
 {
     options.Filters.Add<ModelAttributeErrorFilter>();
+    options.Filters.Add<ApiExceptionFilter>();
 });
 
 var app = builder.Build();

--- a/GatewayApp/Backend/Plantmonitor.Shared/Extensions/StringExtensions.cs
+++ b/GatewayApp/Backend/Plantmonitor.Shared/Extensions/StringExtensions.cs
@@ -1,10 +1,25 @@
 ﻿using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Text;
+using System.Xml.XPath;
 
 namespace Plantmonitor.Shared.Extensions;
 
 public static class StringExtensions
 {
+    public static decimal? ExtractNumbersFromString(this string text, out string notNumericText)
+    {
+        var numberText = new StringBuilder();
+        var stringText = new StringBuilder();
+        foreach (var c in text)
+        {
+            if (char.IsNumber(c)) numberText.Append(c);
+            else stringText.Append(c);
+        }
+        notNumericText = stringText.ToString();
+        return decimal.TryParse(numberText.ToString(), out var result) ? result : null;
+    }
+
     public static FileData GetBytesFromIrFilePath(this string irFilePath, out int temperatureInK)
     {
         temperatureInK = int.TryParse(Path.GetFileNameWithoutExtension(irFilePath).Split('_').Last(), out var temperature) ? temperature : default;

--- a/GatewayApp/Frontend/Plantmonitor.Website/src/features/automaticPhotoTour/+page.svelte
+++ b/GatewayApp/Frontend/Plantmonitor.Website/src/features/automaticPhotoTour/+page.svelte
@@ -71,7 +71,8 @@
         if (selectedPhotoTour == undefined) return;
         const photoTourClient = new AutomaticPhotoTourClient();
         selectedPhotoTour.finished = !selectedPhotoTour.finished;
-        await photoTourClient.pausePhotoTour(selectedPhotoTour.id, selectedPhotoTour.finished);
+        const result = await photoTourClient.pausePhotoTour(selectedPhotoTour.id, selectedPhotoTour.finished).try();
+        if (result.hasError) selectedPhotoTour.finished = !selectedPhotoTour.finished;
         existingPhototours = existingPhototours;
     }
 

--- a/GatewayApp/Frontend/Plantmonitor.Website/src/features/deviceProgramming/PictureStreamer.svelte
+++ b/GatewayApp/Frontend/Plantmonitor.Website/src/features/deviceProgramming/PictureStreamer.svelte
@@ -2,7 +2,7 @@
     import type {HubConnection} from "@microsoft/signalr";
     import {DeviceStreaming} from "~/services/DeviceStreaming";
     import {CameraType} from "~/services/GatewayAppApi";
-    import {CvInterop, ThermalImage} from "../deviceConfiguration/CvInterop";
+    import {CvInterop, IrHeight, IrWidth, ThermalImage} from "../deviceConfiguration/CvInterop";
     import {dev} from "$app/environment";
     import {TooltipCreator, TooltipCreatorResult} from "../reuseableComponents/TooltipCreator";
 
@@ -13,7 +13,7 @@
     let currentTime: Date | undefined;
     let lastPointerPosition: MouseEvent | undefined;
     let tooltip: TooltipCreatorResult | undefined;
-    const irImageBytes = 120 * 160 * 4;
+    const irImageBytes = IrHeight * IrWidth * 4;
     let pixelConverter: ((x: number, y: number) => number) | undefined;
     export let firstImageReceived = false;
     export let firstDataReceived = false;

--- a/GatewayApp/Frontend/Plantmonitor.Website/src/features/photoStitching/+page.svelte
+++ b/GatewayApp/Frontend/Plantmonitor.Website/src/features/photoStitching/+page.svelte
@@ -106,18 +106,26 @@
     {#each _availableTours as tour}
         <button
             on:click={async () => await selectedTourChanged(tour)}
-            class="col-md-1 me-2 p-2 mt-2 alert {_selectedTour === tour ? 'bg-info bg-opacity-50' : ''}  border-dark">
+            class="col-md-1 me-2 p-2 mt-2 alert {_selectedTour?.id == tour.id ? 'bg-info bg-opacity-50' : ''}  border-dark">
             {tour.name}
         </button>
     {/each}
 </div>
 <div class="row">
     <div style="overflow-y: auto;height:80vh" class="d-flex flex-column col-md-2">
-        {#each _pictureTrips as series}
-            <button on:click={async () => await selectedTripChanged(series)} class="row border-secondary border mt-2">
-                <div class="col-md-6">{series.timeStamp.toLocaleString()}</div>
-                <div class="col-md-3">IR: {series.irData.count}</div>
-                <div class="col-md-3">VIS: {series.visData.count}</div>
+        {#each _pictureTrips as { tripId, timeStamp, irData, visData }, i}
+            {@const polyLength = _plants
+                .flatMap((p) => p.extractionMetaData.map((et) => et.tripWithExtraction))
+                .filter((p) => p == tripId).length}
+            <button
+                on:click={async () => await selectedTripChanged(_pictureTrips[i])}
+                class="row border-secondary border mt-2 {tripId == _selectedTrip?.tripId ? 'bg-info bg-opacity-50' : ''}">
+                <div class="col-md-6 p-1">{timeStamp.toLocaleString()}</div>
+                <div class="col-md-2 p-1">IR<br /> {irData.count}</div>
+                <div class="col-md-2 p-1">VIS {visData.count}</div>
+                <div class="col-md-2 p-1">
+                    {polyLength > 0 ? "Polys " + polyLength : ""}
+                </div>
             </button>
         {/each}
     </div>
@@ -150,11 +158,17 @@
         <div style="overflow-y:auto;height:60vh" class="mt-3">
             {#if _selectedTrip != undefined}
                 {#each _plants as plant}
+                    {@const template = _extractionTemplatesOfTrip.find((et) => et.photoTourPlantFk == plant.id)}
                     <button
                         on:click={() => ($selectedPhotoTourPlantInfo = [plant])}
                         class="d-flex flex-column border mb-2 col-md-11 bg-opacity-25
                         {$selectedPhotoTourPlantInfo?.find((p) => p.id == plant.id) != undefined ? 'bg-info' : 'bg-white'}">
-                        <div>Pos: {_extractionTemplatesOfTrip.find((et) => et.photoTourPlantFk == plant.id)?.motorPosition}</div>
+                        <div class="d-flex flex-row justify-content-between col-md-12">
+                            <div>
+                                Pos: {template?.motorPosition}
+                            </div>
+                            <div>{template?.photoTripFk == _selectedTrip.tripId ? "Poly" : ""}</div>
+                        </div>
                         <div
                             style="align-self: center;"
                             class={_extractionTemplatesOfTrip.find((et) => et.photoTourPlantFk == plant.id)?.motorPosition ==

--- a/GatewayApp/Frontend/Plantmonitor.Website/src/features/photoStitching/ImageCutter.svelte
+++ b/GatewayApp/Frontend/Plantmonitor.Website/src/features/photoStitching/ImageCutter.svelte
@@ -148,12 +148,6 @@
         if (_cutPolygon.length <= 2 || _selectedImage == null || _selectedPlant == undefined) return;
         _cutPolygon.push(_cutPolygon[0]);
         drawLine();
-        const croppedImage = await cropImage(
-            _selectedImage.imageUrl,
-            _cutPolygon.map((p) => ({x: p.point.x / _imageRatio, y: p.point.y / _imageRatio}))
-        );
-        const qrCode = _cvInterop.readQRCode(croppedImage);
-        console.log(qrCode);
         _cutPolygon = _cutPolygon;
         _polygonValid = true;
     }
@@ -199,6 +193,10 @@
         _cutPolygon = [];
         await changeImage(_currentImageIndex);
         if (template == undefined) return;
+        if (template.id != _selectedPhotoTrip.tripId) {
+            alert("Polygon must be deleted from trip: " + template.applicablePhotoTripFrom.toLocaleString());
+            return;
+        }
         await client.removePlantImageSections([template.id]);
         $plantPolygonChanged = _selectedPlant;
     }

--- a/GatewayApp/Frontend/Plantmonitor.Website/src/features/photoStitching/ImageCutter.svelte
+++ b/GatewayApp/Frontend/Plantmonitor.Website/src/features/photoStitching/ImageCutter.svelte
@@ -124,8 +124,12 @@
         _cutPolygon = [];
         event.preventDefault();
     }
-    function addLine(event: MouseEvent) {
+    async function addLine(event: MouseEvent) {
         if (_selectedPlant == undefined) return;
+        if (isPolygonValid()) {
+            _cutPolygon = [];
+            await changeImage(_currentImageIndex);
+        }
         _cutPolygon.push({point: new NpgsqlPoint({x: event.offsetX, y: event.offsetY})});
         drawLine();
     }

--- a/GatewayApp/Frontend/Plantmonitor.Website/src/features/replayPictures/+page.svelte
+++ b/GatewayApp/Frontend/Plantmonitor.Website/src/features/replayPictures/+page.svelte
@@ -6,6 +6,7 @@
     import type {ReplayedImage} from "./ReplayedImage";
     import {selectedDevice} from "../store";
     import {type IIrCameraOffset, PictureClient, IrCameraOffset} from "~/services/GatewayAppApi";
+    import {onDestroy} from "svelte";
     let getLeftSelectedImage: () => ReplayedImage | undefined;
     let getRightSelectedImage: () => ReplayedImage | undefined;
     let imageOffsetCalculator: ImageOffsetCalculator | undefined;
@@ -27,6 +28,9 @@
         const newOffset: IIrCameraOffset = {left: leftOffset, top: topOffset};
         pictureClient.updateIrOffset(new IrCameraOffset(newOffset), $selectedDevice?.ip);
     }
+    onDestroy(() => {
+        imageOffsetCalculator?.delete();
+    });
     async function AlignImages() {
         let leftImage = getLeftSelectedImage();
         let rightImage = getRightSelectedImage();

--- a/GatewayApp/Frontend/Plantmonitor.Website/src/features/store.ts
+++ b/GatewayApp/Frontend/Plantmonitor.Website/src/features/store.ts
@@ -1,8 +1,10 @@
 import { writable, type Writable } from "svelte/store";
 import type { DeviceHealthState } from "~/services/GatewayAppApi";
 import { PhotoTourPlantInfo } from './../services/GatewayAppApi';
+import type { ImageToCut } from "./photoStitching/ImageToCut";
 
 export const selectedDevice: Writable<DeviceHealthState | undefined> = writable(undefined);
 export const allDevices: Writable<DeviceHealthState[]> = writable([]);
 export const selectedPhotoTourPlantInfo: Writable<PhotoTourPlantInfo[] | undefined> = writable(undefined);
 export const plantPolygonChanged: Writable<PhotoTourPlantInfo | undefined> = writable(undefined);
+export const imageToCutChanged: Writable<ImageToCut | undefined> = writable(undefined);

--- a/GatewayApp/Frontend/Plantmonitor.Website/src/tests/imageManipulation/irConversion.spec.ts
+++ b/GatewayApp/Frontend/Plantmonitor.Website/src/tests/imageManipulation/irConversion.spec.ts
@@ -1,13 +1,12 @@
-import { MovementPoint } from "~/services/GatewayAppApi";
 import { promises as fs } from "fs";
 import path from 'path';
 
 
 describe("Test", () => {
-	test("Test", async () => {
-		const filePath = path.join(__dirname, 'test');
-		const fileContent: Uint8Array = await fs.readFile(filePath);
-		console.log(new DataView(fileContent.slice(0, 4).buffer).getInt32(0, true));
-		console.log(fileContent.length/4+" should be "+(160*120));
-	})
+    test("Test", async () => {
+        const filePath = path.join(__dirname, 'test');
+        const fileContent: Uint8Array = await fs.readFile(filePath);
+        console.log(new DataView(fileContent.slice(0, 4).buffer).getInt32(0, true));
+        console.log(fileContent.length / 4 + " should be " + (160 * 120));
+    })
 });


### PR DESCRIPTION


### Commit messages for #161

- 73eedfafd545356e4bae898487d77c374b3d0989 giving an appropriate error message, when a polygon from another trip is about to be deleted
- 7b5131647bc355f059211155acf870689fd4133d Repeated clicks after a polygon is finished lead to the drawing of a new polygon
- 8c630056eed8f222f4db45958dce7c14e543e1e6 plant names are now shown, when the polygon around is completed
- 2021633030b45ef32a622fbb1ca667beba1579f9 fixed region of interest calculation. The minimum polygon size and maximum polygon size might be negative. This is a fix for the issue, along with a test.
- 59d35be91f16721c5b4ad26a60803fca99a6abdd removed padding from the function call, as white borders are added anyway.
The plant names are now added aswell in the padded region, so no overlap with the polygon pixels should be possible.
- cad021c32c1e0c929192544a420002bcba03ea09 Sorting of plants is now done by first comparing the text only name and then sorting after the numbers in the text in a numeric way. This ensures correct ordering, even when having different lengths of numeric strings
- f061c513dcbe240475b0eeb3266099d8bca6f326 better naming of test
- 0523b6560830a3fea71d14141f9aac8e5f5d854e Deselection of selected images does not work fine.
Next is to only fetch the plant data with the appropriate template for the current trip and not all at once
- 16601ee491fef1b85eef8e6abdbe952f167cc816 only extractions applicable to the current trip are now shown
- e213e95ebce108066dd59cf98e45d1b5c13d50d2 Trips indicate now when they define a Polygon for further Trips. The sum of defined Polygon is indicated for each trip and when selected respective Plants have a "Poly" as info
- 8495f225a65d7e834b58dcd3d3dcfeaa6bd859ed pausephototour is now checked, whether it throws an error. If it errors, then the state is resetted
- cb7e6230dbb30a7168571398ee27135a7737411d added an api exception filter to get finally proper logging during production builds.
When an exception on the backend occurs, the message is sent as json result to the client. The client can then show the error message in a proper way
- 982d0fca1332ae0412c10a545c02cafcac1f070b An estimation of the field of view is now shown in the Photo stitching Tab.
Fine adjustments should be done later via another tab. This is only to estimate which plants are roughly covered by both, ir and vis.
- b4a61a42b6bcb6e584bcf809b8123390f7a5cd2c Image alignment of vis and ir is now deleted upon navigation