### PR TITLE
 align individual plants

### DIFF
--- a/GatewayApp/Backend/Plantmonitor.DataModel/DataModel/DataContext.cs
+++ b/GatewayApp/Backend/Plantmonitor.DataModel/DataModel/DataContext.cs
@@ -166,7 +166,6 @@ public partial class DataContext : DbContext, IDataContext
             entity.Property(e => e.Id).HasColumnName("id");
             entity.Property(e => e.Message).HasColumnName("message");
             entity.Property(e => e.PhotoTourFk).HasColumnName("photo_tour_fk");
-            entity.Property(e => e.ReferencesEvent).HasColumnName("references_event");
             entity.Property(e => e.Timestamp)
                 .HasDefaultValueSql("now()")
                 .HasColumnName("timestamp");
@@ -175,10 +174,6 @@ public partial class DataContext : DbContext, IDataContext
                 .HasForeignKey(d => d.PhotoTourFk)
                 .OnDelete(DeleteBehavior.ClientSetNull)
                 .HasConstraintName("photo_tour_event_photo_tour_fk_fkey");
-
-            entity.HasOne(d => d.ReferencesEventNavigation).WithMany(p => p.InverseReferencesEventNavigation)
-                .HasForeignKey(d => d.ReferencesEvent)
-                .HasConstraintName("photo_tour_event_references_event_fkey");
         });
 
         modelBuilder.Entity<PhotoTourPlant>(entity =>
@@ -191,7 +186,7 @@ public partial class DataContext : DbContext, IDataContext
             entity.Property(e => e.Comment).HasColumnName("comment");
             entity.Property(e => e.Name).HasColumnName("name");
             entity.Property(e => e.PhotoTourFk).HasColumnName("photo_tour_fk");
-            entity.Property(e => e.QrCode).HasColumnName("qr_code");
+            entity.Property(e => e.Position).HasColumnName("position");
 
             entity.HasOne(d => d.PhotoTourFkNavigation).WithMany(p => p.PhotoTourPlants)
                 .HasForeignKey(d => d.PhotoTourFk)
@@ -201,7 +196,7 @@ public partial class DataContext : DbContext, IDataContext
 
         modelBuilder.Entity<PhotoTourTrip>(entity =>
         {
-            entity.HasKey(e => e.Id).HasName("photo_tour_journey_pkey");
+            entity.HasKey(e => e.Id).HasName("photo_tour_trip_pkey");
 
             entity.ToTable("photo_tour_trip", "plantmonitor");
 
@@ -217,7 +212,7 @@ public partial class DataContext : DbContext, IDataContext
             entity.HasOne(d => d.PhotoTourFkNavigation).WithMany(p => p.PhotoTourTrips)
                 .HasForeignKey(d => d.PhotoTourFk)
                 .OnDelete(DeleteBehavior.ClientSetNull)
-                .HasConstraintName("photo_tour_journey_photo_tour_fk_fkey");
+                .HasConstraintName("photo_tour_trip_photo_tour_fk_fkey");
         });
 
         modelBuilder.Entity<PlantExtractionTemplate>(entity =>

--- a/GatewayApp/Backend/Plantmonitor.DataModel/DataModel/PhotoTourEvent.cs
+++ b/GatewayApp/Backend/Plantmonitor.DataModel/DataModel/PhotoTourEvent.cs
@@ -13,11 +13,5 @@ public partial class PhotoTourEvent
 
     public DateTime Timestamp { get; set; }
 
-    public long? ReferencesEvent { get; set; }
-
-    public virtual ICollection<PhotoTourEvent> InverseReferencesEventNavigation { get; set; } = new List<PhotoTourEvent>();
-
     public virtual AutomaticPhotoTour PhotoTourFkNavigation { get; set; } = null!;
-
-    public virtual PhotoTourEvent? ReferencesEventNavigation { get; set; }
 }

--- a/GatewayApp/Backend/Plantmonitor.DataModel/DataModel/PhotoTourPlant.cs
+++ b/GatewayApp/Backend/Plantmonitor.DataModel/DataModel/PhotoTourPlant.cs
@@ -11,7 +11,7 @@ public partial class PhotoTourPlant
 
     public string Comment { get; set; } = null!;
 
-    public string? QrCode { get; set; }
+    public string? Position { get; set; }
 
     public long PhotoTourFk { get; set; }
 

--- a/GatewayApp/Backend/Plantmonitor.DataModel/DataModel/PlantExtractionTemplate.cs
+++ b/GatewayApp/Backend/Plantmonitor.DataModel/DataModel/PlantExtractionTemplate.cs
@@ -16,11 +16,11 @@ public partial class PlantExtractionTemplate
 
     public NpgsqlPoint IrBoundingBoxOffset { get; set; }
 
-    public int MotorPosition { get; set; }
-
     public float BoundingBoxHeight { get; set; }
 
     public float BoundingBoxWidth { get; set; }
+
+    public int MotorPosition { get; set; }
 
     public virtual PhotoTourPlant PhotoTourPlantFkNavigation { get; set; } = null!;
 

--- a/GatewayApp/Backend/Plantmonitor.DataModel/DatabasePatches/007_DatabaseRenaming.sql
+++ b/GatewayApp/Backend/Plantmonitor.DataModel/DatabasePatches/007_DatabaseRenaming.sql
@@ -1,0 +1,4 @@
+ALTER TABLE IF EXISTS plantmonitor.photo_tour_event DROP COLUMN IF EXISTS references_event;
+ALTER TABLE IF EXISTS plantmonitor.photo_tour_plant RENAME qr_code TO "position";
+
+update plantmonitor.configuration_data set value='7' where key='PatchNumber';

--- a/GatewayApp/Backend/Plantmonitor.Server.Tests/Features/ImageStitching/ImageCropperTests.cs
+++ b/GatewayApp/Backend/Plantmonitor.Server.Tests/Features/ImageStitching/ImageCropperTests.cs
@@ -120,6 +120,21 @@ public class ImageCropperTests
     }
 
     [Fact]
+    public void CropImage_OutOfRange_ShouldNotError()
+    {
+        var sut = CreateImageCropper();
+        var applicationPath = Directory.GetCurrentDirectory().GetApplicationRootGitPath();
+        var irFile = $"{applicationPath}/PlantMonitorControl.Tests/TestData/CropTest/2024-07-28_20-33-19-047_-6000_29710.rawir";
+        var visFile = $"{applicationPath}/PlantMonitorControl.Tests/TestData/CropTest/2024-07-28_20-26-10-207_-6000_0.jpg";
+        var result = sut.CropImages(visFile, irFile, s_singlePlantBottomMiddlePolygon_1WeekLaterAndMoved, new(-1000, -1000), 960);
+        sut.ApplyIrColorMap(result.IrImage!);
+        result.IrImage!.Height.Should().Be(0);
+        result.IrImage!.Width.Should().Be(0);
+        result.IrImage!.Dispose();
+        result.VisImage.Dispose();
+    }
+
+    [Fact]
     public void CropImage_IR_ShouldWork()
     {
         var sut = CreateImageCropper();

--- a/GatewayApp/Backend/Plantmonitor.Server/Features/ImageStitching/ImageCropper.cs
+++ b/GatewayApp/Backend/Plantmonitor.Server/Features/ImageStitching/ImageCropper.cs
@@ -85,6 +85,7 @@ public class ImageCropper() : IImageCropper
 
     public void ApplyIrColorMap(Mat irImage)
     {
+        if (irImage.Height == 0 || irImage.Width == 0) return;
         var baselineMat = new Mat(irImage.Rows, irImage.Cols, irImage.Depth, 1);
         baselineMat.SetTo(new MCvScalar(ZeroDegreeCelsius + 1500));
         var scaleMat = new Mat(irImage.Rows, irImage.Cols, DepthType.Cv32F, 1);
@@ -115,6 +116,7 @@ public class ImageCropper() : IImageCropper
 
     public byte[] MatToByteArray(Mat mat, bool disposeMat = true)
     {
+        if (mat.Width == 0 || mat.Height == 0) return [];
         var resultFile = Guid.NewGuid().ToString() + ".png";
         var fullPath = Path.Combine(Path.GetTempPath(), resultFile);
         CvInvoke.Imwrite(fullPath, mat);

--- a/GatewayApp/Backend/Plantmonitor.Server/Features/ImageStitching/ImageCropper.cs
+++ b/GatewayApp/Backend/Plantmonitor.Server/Features/ImageStitching/ImageCropper.cs
@@ -17,6 +17,8 @@ public interface IImageCropper
     void ApplyIrColorMap(Mat irImage);
 
     Mat CreateRawIr(Mat irImage);
+
+    byte[] MatToByteArray(Mat mat, bool disposeMat = true);
 }
 
 public class ImageCropper() : IImageCropper
@@ -109,6 +111,15 @@ public class ImageCropper() : IImageCropper
         irMat.SetTo(tempArray);
         isIr = true;
         return irMat;
+    }
+
+    public byte[] MatToByteArray(Mat mat, bool disposeMat = true)
+    {
+        var resultFile = Guid.NewGuid().ToString() + ".png";
+        var fullPath = Path.Combine(Path.GetTempPath(), resultFile);
+        CvInvoke.Imwrite(fullPath, mat);
+        if (disposeMat) mat.Dispose();
+        return File.ReadAllBytes(fullPath);
     }
 
     public void Resize(Mat mat, int height)

--- a/GatewayApp/Backend/Plantmonitor.Server/Features/ImageStitching/ImageCropper.cs
+++ b/GatewayApp/Backend/Plantmonitor.Server/Features/ImageStitching/ImageCropper.cs
@@ -119,7 +119,9 @@ public class ImageCropper() : IImageCropper
         var fullPath = Path.Combine(Path.GetTempPath(), resultFile);
         CvInvoke.Imwrite(fullPath, mat);
         if (disposeMat) mat.Dispose();
-        return File.ReadAllBytes(fullPath);
+        var result = File.ReadAllBytes(fullPath);
+        File.Delete(fullPath);
+        return result;
     }
 
     public void Resize(Mat mat, int height)

--- a/GatewayApp/Backend/Plantmonitor.Server/Features/ImageStitching/PhotoStitchingController.cs
+++ b/GatewayApp/Backend/Plantmonitor.Server/Features/ImageStitching/PhotoStitchingController.cs
@@ -12,10 +12,10 @@ namespace Plantmonitor.Server.Features.DeviceProgramming;
 public class PhotoStitchingController(IDataContext context, IVirtualImageWorker virtualImageWorker, IImageCropper cropper)
 {
     public record struct AddPlantModel(IEnumerable<PlantModel> Plants, long TourId);
-    public record struct PhotoTourPlantInfo(long Id, string Name, string Comment, string? QrCode, long PhotoTourFk, IEnumerable<ExtractionMetaData> ExtractionMetaData);
+    public record struct PhotoTourPlantInfo(long Id, string Name, string Comment, string? Position, long PhotoTourFk, IEnumerable<ExtractionMetaData> ExtractionMetaData);
     public record struct ExtractionMetaData(long TripWithExtraction, int MotorPosition, DateTime ExtractionTime);
     public record struct PlantExtractionTemplateModel(long Id, long PhotoTripFk, long PhotoTourPlantFk, NpgsqlPolygon PhotoBoundingBox, NpgsqlPoint IrBoundingBoxOffset, int MotorPosition, DateTime ApplicablePhotoTripFrom);
-    public record struct PlantModel(string Name, string Comment, string QrCode);
+    public record struct PlantModel(string Name, string Comment, string Position);
     public record struct IrOffsetFineAdjustment(long ExtractionTemplateId, NpgsqlPoint NewIrOffset);
     public record struct PlantImageSection(int StepCount, long PhotoTripId, NpgsqlPolygon Polygon, NpgsqlPoint IrPolygonOffset, long PlantId);
     public record struct ImageCropPreview(byte[] IrImage, byte[] VisImage, NpgsqlPoint CurrentOffset);
@@ -27,7 +27,7 @@ public class PhotoStitchingController(IDataContext context, IVirtualImageWorker 
             .Include(ptp => ptp.PlantExtractionTemplates)
             .ThenInclude(pet => pet.PhotoTripFkNavigation)
             .Where(ptp => ptp.PhotoTourFk == tourId)
-            .Select(ptp => new PhotoTourPlantInfo(ptp.Id, ptp.Name, ptp.Comment, ptp.QrCode, ptp.PhotoTourFk, ptp.PlantExtractionTemplates
+            .Select(ptp => new PhotoTourPlantInfo(ptp.Id, ptp.Name, ptp.Comment, ptp.Position, ptp.PhotoTourFk, ptp.PlantExtractionTemplates
                 .Select(pet => new ExtractionMetaData(pet.PhotoTripFk, pet.MotorPosition, pet.PhotoTripFkNavigation.Timestamp))));
     }
 
@@ -146,12 +146,12 @@ public class PhotoStitchingController(IDataContext context, IVirtualImageWorker 
     public void AddPlantsToTour(AddPlantModel plants)
     {
         var newNames = plants.Plants.Select(p => p.Name).ToHashSet();
-        var newQrCodes = plants.Plants.Select(p => p.QrCode).ToHashSet();
+        var newQrCodes = plants.Plants.Select(p => p.Position).ToHashSet();
         var existingNames = context.PhotoTourPlants.Where(ptp => ptp.PhotoTourFk == plants.TourId && newNames.Contains(ptp.Name));
-        var existingQrCodes = context.PhotoTourPlants.Where(ptp => ptp.PhotoTourFk == plants.TourId && ptp.QrCode != null && ptp.QrCode.Length > 0 && newQrCodes.Contains(ptp.QrCode));
+        var existingQrCodes = context.PhotoTourPlants.Where(ptp => ptp.PhotoTourFk == plants.TourId && ptp.Position != null && ptp.Position.Length > 0 && newQrCodes.Contains(ptp.Position));
         if (existingNames.Any() || existingQrCodes.Any())
         {
-            var message = $"The following names exist already: {existingNames.Select(en => en.Name).Concat(", ")}\n The following QR-Codes exist already: {existingQrCodes.Select(qr => qr.QrCode).Concat(", ")}";
+            var message = $"The following names exist already: {existingNames.Select(en => en.Name).Concat(", ")}\n The following QR-Codes exist already: {existingQrCodes.Select(qr => qr.Position).Concat(", ")}";
             throw new Exception(message);
         }
         context.PhotoTourPlants.AddRange(plants.Plants.Select(p => new PhotoTourPlant()
@@ -159,7 +159,7 @@ public class PhotoStitchingController(IDataContext context, IVirtualImageWorker 
             Comment = p.Comment,
             Name = p.Name,
             PhotoTourFk = plants.TourId,
-            QrCode = p.QrCode,
+            Position = p.Position,
         }));
         context.SaveChanges();
     }

--- a/GatewayApp/Backend/Plantmonitor.Server/Features/ImageStitching/VirtualImageWorker.cs
+++ b/GatewayApp/Backend/Plantmonitor.Server/Features/ImageStitching/VirtualImageWorker.cs
@@ -78,8 +78,6 @@ public class VirtualImageWorker(IServiceScopeFactory scopeFactory, IEnvironmentC
             logger.LogWarning("No extraction templates defined for tour {tour}. Exiting", tripToProcess.PhotoTourFkNavigation.Name);
             return;
         }
-        var maxBoundingBoxHeight = (int)float.Ceiling(extractionTemplates.Max(bb => bb.BoundingBoxHeight));
-        var maxBoundingBoxWidth = (int)float.Ceiling(extractionTemplates.Max(bb => bb.BoundingBoxWidth));
         var imagesToCreate = dataContext.PhotoTourTrips
             .Where(ptt => ptt.VirtualPicturePath == null && ptt.PhotoTourFk == tripToProcess.PhotoTourFk)
             .ToList();
@@ -132,7 +130,9 @@ public class VirtualImageWorker(IServiceScopeFactory scopeFactory, IEnvironmentC
                 virtualImageList[^1].ColoredIrImage = colorMat;
             }
             logger.LogInformation("Stitching virtual image together");
-            var virtualImage = stitcher.CreateVirtualImage(virtualImageList, maxBoundingBoxWidth, maxBoundingBoxHeight);
+            var maxHeight = virtualImageList.Select(v => v.VisImage?.Height ?? 10).OrderByDescending(h => h).FirstOrDefault();
+            var maxWidth = virtualImageList.Select(v => v.VisImage?.Width ?? 10).OrderByDescending(h => h).FirstOrDefault();
+            var virtualImage = stitcher.CreateVirtualImage(virtualImageList, maxWidth, maxHeight);
             logger.LogInformation("Fetching additional metadata");
             var fullMetaDataTable = AddAditionalMetaData(dataContext, tripToProcess, virtualImageList, virtualImage);
 

--- a/GatewayApp/Backend/Plantmonitor.Server/Features/ImageStitching/VirtualImageWorker.cs
+++ b/GatewayApp/Backend/Plantmonitor.Server/Features/ImageStitching/VirtualImageWorker.cs
@@ -117,8 +117,8 @@ public class VirtualImageWorker(IServiceScopeFactory scopeFactory, IEnvironmentC
                     logger.LogWarning("No vis image found. Moving to next plant.");
                     continue;
                 }
-                logger.LogInformation("Using images vis: {vis} and ir: {ir} for cropping", visImage.FileName, irImage?.File ?? "NA");
-                var matResults = cropper.CropImages(visImage.FileName, irImage?.File, [.. extractionTemplate.PhotoBoundingBox],
+                logger.LogInformation("Using images vis: {vis} and ir: {ir} for cropping", visImage.FileName, irImage.FileName ?? "NA");
+                var matResults = cropper.CropImages(visImage.FileName, irImage.FileName, [.. extractionTemplate.PhotoBoundingBox],
                     extractionTemplate.IrBoundingBoxOffset, VirtualPlantImageCropHeight);
                 virtualImageList[^1].VisImage = matResults.VisImage;
                 virtualImageList[^1].VisImageTime = visImage.Formatter.Timestamp;

--- a/GatewayApp/Backend/Plantmonitor.Server/Features/ImageStitching/VirtualImageWorker.cs
+++ b/GatewayApp/Backend/Plantmonitor.Server/Features/ImageStitching/VirtualImageWorker.cs
@@ -20,7 +20,7 @@ public interface IVirtualImageWorker
 public class VirtualImageWorker(IServiceScopeFactory scopeFactory, IEnvironmentConfiguration configuration,
     ILogger<VirtualImageWorker> logger) : IHostedService, IVirtualImageWorker
 {
-    private const int VirtualPlantImageCropHeight = 960;
+    public const int VirtualPlantImageCropHeight = 960;
     private Timer? _timer;
     private static readonly object s_lock = new();
     private static bool s_isRunning;
@@ -109,24 +109,20 @@ public class VirtualImageWorker(IServiceScopeFactory scopeFactory, IEnvironmentC
                     Name = plant.Name,
                 });
                 if (extractionTemplate == null || !Path.Exists(image.VisDataFolder) || !Path.Exists(image.IrDataFolder)) continue;
-                var visImage = Directory.GetFiles(image.VisDataFolder)
-                    .Select(vi => new { Success = CameraStreamFormatter.FromFileLazy(vi, out var formatter), File = vi, Formatter = formatter })
-                    .FirstOrDefault(f => f.Success && f.Formatter.Steps == extractionTemplate.MotorPosition);
-                var irImage = Directory.GetFiles(image.IrDataFolder)
-                    .Select(vi => new { Success = CameraStreamFormatter.FromFileLazy(vi, out var formatter), File = vi, Formatter = formatter })
-                    .FirstOrDefault(f => f.Success && f.Formatter.Steps == extractionTemplate.MotorPosition);
+                var visImage = CameraStreamFormatter.FindInFolder(image.VisDataFolder, extractionTemplate.MotorPosition);
+                var irImage = CameraStreamFormatter.FindInFolder(image.IrDataFolder, extractionTemplate.MotorPosition);
 
-                if (visImage == null)
+                if (visImage.FileName == null || visImage.Formatter == null)
                 {
                     logger.LogWarning("No vis image found. Moving to next plant.");
                     continue;
                 }
-                logger.LogInformation("Using images vis: {vis} and ir: {ir} for cropping", visImage.File, irImage?.File ?? "NA");
-                var matResults = cropper.CropImages(visImage.File, irImage?.File, [.. extractionTemplate.PhotoBoundingBox],
+                logger.LogInformation("Using images vis: {vis} and ir: {ir} for cropping", visImage.FileName, irImage?.File ?? "NA");
+                var matResults = cropper.CropImages(visImage.FileName, irImage?.File, [.. extractionTemplate.PhotoBoundingBox],
                     extractionTemplate.IrBoundingBoxOffset, VirtualPlantImageCropHeight);
                 virtualImageList[^1].VisImage = matResults.VisImage;
                 virtualImageList[^1].VisImageTime = visImage.Formatter.Timestamp;
-                if (irImage == null) continue;
+                if (irImage.Formatter == null || irImage.FileName == null) continue;
                 virtualImageList[^1].IrImageTime = irImage.Formatter.Timestamp;
                 virtualImageList[^1].IrTemperatureInK = irImage.Formatter.TemperatureInK;
                 if (matResults.IrImage?.Cols == 0 || matResults.IrImage?.Rows == 0) continue;

--- a/GatewayApp/Backend/Plantmonitor.Shared/Features/ImageStreaming/CameraStreamFormatter.cs
+++ b/GatewayApp/Backend/Plantmonitor.Shared/Features/ImageStreaming/CameraStreamFormatter.cs
@@ -32,6 +32,13 @@ public class CameraStreamFormatter
     public byte[]? PictureData { get; set; }
     public Func<byte[]?> FetchImageData { get; set; } = () => null;
 
+    public static (string? FileName, CameraStreamFormatter? Formatter) FindInFolder(string path, int motorPosition)
+    {
+        return Directory.GetFiles(path)
+            .Select(file => FromFileLazy(file, out var formatter) ? (File: file, Formatter: formatter) : (null, null))
+            .FirstOrDefault(file => file.File != null && file.Formatter?.Steps == motorPosition);
+    }
+
     public static bool FromFileLazy(string path, out CameraStreamFormatter result)
     {
         result = new();

--- a/GatewayApp/Frontend/Plantmonitor.Website/src/features/photoStitching/+page.svelte
+++ b/GatewayApp/Frontend/Plantmonitor.Website/src/features/photoStitching/+page.svelte
@@ -95,7 +95,7 @@
             new PlantModel({
                 comment: _newPlant.comment,
                 name: _newPlant.name,
-                qrCode: _newPlant.qrCode ?? ""
+                position: _newPlant.position ?? ""
             })
         ];
         await stitchingClient.addPlantsToTour(new AddPlantModel({plants: plants, tourId: _selectedTour.id}));
@@ -146,7 +146,7 @@
         <div class="d-flex flex-row justify-content-center mb-2">
             <button on:click={recalculateVirtualPictures} class="btn btn-primary">Recalculate Virtual Pictures</button>
         </div>
-        <TextInput label="QR-Code" bind:value={_newPlant.qrCode}></TextInput>
+        <TextInput label="Position" bind:value={_newPlant.position}></TextInput>
         <TextInput label="Name" bind:value={_newPlant.name}></TextInput>
         <TextInput label="Comment" bind:value={_newPlant.comment}></TextInput>
         <div class="d-flex flex-row justify-content-between mt-2">
@@ -174,7 +174,7 @@
                         <div
                             style="align-self: center;"
                             class={template?.motorPosition == _selectedImage?.stepCount ? "fw-bold" : ""}>
-                            {plant.name} - {plant.qrCode?.isEmpty() ? "No QR" : plant.qrCode}
+                            {plant.name} - {plant.position?.isEmpty() ? "No QR" : plant.position}
                         </div>
                         <div style="align-self: center;">{plant.comment}</div>
                     </button>

--- a/GatewayApp/Frontend/Plantmonitor.Website/src/features/photoStitching/+page.svelte
+++ b/GatewayApp/Frontend/Plantmonitor.Website/src/features/photoStitching/+page.svelte
@@ -183,4 +183,7 @@
         </div>
     </div>
 </div>
-<IrFineAdjustment bind:_extractionTemplates={_extractionTemplatesOfTrip} bind:_selectedTrip></IrFineAdjustment>
+<hr  class="m-3"/>
+{#if _selectedTrip != undefined}
+    <IrFineAdjustment bind:_extractionTemplates={_extractionTemplatesOfTrip} bind:_selectedTrip></IrFineAdjustment>
+{/if}

--- a/GatewayApp/Frontend/Plantmonitor.Website/src/features/photoStitching/+page.svelte
+++ b/GatewayApp/Frontend/Plantmonitor.Website/src/features/photoStitching/+page.svelte
@@ -19,6 +19,7 @@
     import {imageToCutChanged, plantPolygonChanged, selectedDevice, selectedPhotoTourPlantInfo} from "../store";
     import type {Unsubscriber} from "svelte/motion";
     import type {ImageToCut} from "./ImageToCut";
+    import IrFineAdjustment from "./IrFineAdjustment.svelte";
     let _availableTours: PhotoTourInfo[] = [];
     let _selectedTour: PhotoTourInfo | undefined;
     let _pictureTrips: PictureTripData[] = [];
@@ -104,7 +105,7 @@
 
 <h3>Available Tours</h3>
 <div class="d-flex flex-row">
-    {#each _availableTours as tour}
+    {#each _availableTours.toSorted((t1, t2) => (t1.lastEvent <= t2.lastEvent ? 1 : -1)) as tour}
         <button
             on:click={async () => await selectedTourChanged(tour)}
             class="col-md-1 me-2 p-2 mt-2 alert {_selectedTour?.id == tour.id ? 'bg-info bg-opacity-50' : ''}  border-dark">
@@ -113,7 +114,7 @@
     {/each}
 </div>
 <div class="row">
-    <div style="overflow-y: auto;height:80vh" class="d-flex flex-column col-md-2">
+    <div style="overflow-y: auto;height:70vh" class="d-flex flex-column col-md-2">
         {#each _pictureTrips as { tripId, timeStamp, irData, visData }, i}
             {@const polyLength = _plants
                 .flatMap((p) => p.extractionMetaData.map((et) => et.tripWithExtraction))
@@ -156,7 +157,7 @@
             <button on:click={() => ($selectedPhotoTourPlantInfo = _plants)} class="btn btn-primary"
                 >Show polygons on image</button>
         </div>
-        <div style="overflow-y:auto;height:60vh" class="mt-3">
+        <div style="overflow-y:auto;height:40vh" class="mt-3">
             {#if _selectedTrip != undefined}
                 {#each _plants as plant}
                     {@const template = _extractionTemplatesOfTrip.find((et) => et.photoTourPlantFk == plant.id)}
@@ -172,10 +173,7 @@
                         </div>
                         <div
                             style="align-self: center;"
-                            class={_extractionTemplatesOfTrip.find((et) => et.photoTourPlantFk == plant.id)?.motorPosition ==
-                            _selectedImage?.stepCount
-                                ? "fw-bold"
-                                : ""}>
+                            class={template?.motorPosition == _selectedImage?.stepCount ? "fw-bold" : ""}>
                             {plant.name} - {plant.qrCode?.isEmpty() ? "No QR" : plant.qrCode}
                         </div>
                         <div style="align-self: center;">{plant.comment}</div>
@@ -185,3 +183,4 @@
         </div>
     </div>
 </div>
+<IrFineAdjustment bind:_extractionTemplates={_extractionTemplatesOfTrip} bind:_selectedTrip></IrFineAdjustment>

--- a/GatewayApp/Frontend/Plantmonitor.Website/src/features/photoStitching/ImageCutter.svelte
+++ b/GatewayApp/Frontend/Plantmonitor.Website/src/features/photoStitching/ImageCutter.svelte
@@ -16,6 +16,7 @@
     import type {HubConnection} from "@microsoft/signalr";
     import {imageToCutChanged, plantPolygonChanged, selectedDevice, selectedPhotoTourPlantInfo} from "../store";
     import type {Unsubscriber} from "svelte/motion";
+    import IrFineAdjustment from "./IrFineAdjustment.svelte";
 
     export let deviceId: string;
     export let irSeries: string;

--- a/GatewayApp/Frontend/Plantmonitor.Website/src/features/photoStitching/ImageCutter.svelte
+++ b/GatewayApp/Frontend/Plantmonitor.Website/src/features/photoStitching/ImageCutter.svelte
@@ -305,7 +305,7 @@
                 <button on:click={() => connectPolygon()} class="btn btn-primary">Connect Cut</button>
             {/if}
         {/if}
-        <button on:click={removePolygon} class="btn btn-danger">Delete Polygon</button>
+        <button on:click={removePolygon} class="btn btn-danger ms-2">Delete Polygon</button>
         <button on:click={savePolygon} disabled={!_polygonValid} class="ms-2 btn btn-success">Save Polygon</button>
     </div>
 </div>

--- a/GatewayApp/Frontend/Plantmonitor.Website/src/features/photoStitching/ImageCutter.svelte
+++ b/GatewayApp/Frontend/Plantmonitor.Website/src/features/photoStitching/ImageCutter.svelte
@@ -28,7 +28,7 @@
     let _images: ImageToCut[] = [];
     let _lastPointerPosition: MouseEvent | undefined;
     let _tooltip: TooltipCreatorResult | undefined;
-    let _cutPolygon: {points: NpgsqlPoint[]; name: string} = {points: [], name: ""};
+    let _cutPolygon: {points: NpgsqlPoint[]; name: string; position: string} = {points: [], name: "", position: ""};
     let _visConnection: HubConnection | undefined;
     let _irConnection: HubConnection | undefined;
     let _selectedPlant: PhotoTourPlantInfo | undefined;
@@ -41,7 +41,7 @@
     onMount(() => {
         startStream();
         const unsubscriber = selectedPhotoTourPlantInfo.subscribe(async (x) => {
-            _cutPolygon = {points: [], name: ""};
+            _cutPolygon = {points: [], name: "", position: ""};
             await refreshImage();
             if (x == undefined) return;
             if (x.length == 1) _selectedPlant = x[0];
@@ -52,7 +52,7 @@
                     (et) => et.photoTourPlantFk == plant.id && et.motorPosition == _selectedImage?.stepCount
                 );
                 if (existingTemplate == undefined) continue;
-                _cutPolygon = {points: [], name: plant.name};
+                _cutPolygon = {points: [], name: plant.name, position: plant.position ?? ""};
                 existingTemplate.photoBoundingBox.forEach((bb) => {
                     _cutPolygon.points.push(new NpgsqlPoint({x: bb.x * _imageRatio, y: bb.y * _imageRatio}));
                     drawLine();
@@ -120,13 +120,13 @@
             currentIndex = currentIndex + 1;
         }
         changeImage(currentIndex);
-        _cutPolygon = {points: [], name: ""};
+        _cutPolygon = {points: [], name: "", position: ""};
         event.preventDefault();
     }
     async function addLine(event: MouseEvent) {
         if (_selectedPlant == undefined) return;
         if (isPolygonValid()) {
-            _cutPolygon = {points: [], name: _selectedPlant.name};
+            _cutPolygon = {points: [], name: _selectedPlant.name, position: _selectedPlant.position ?? ""};
             await refreshImage();
         }
         _cutPolygon.points.push(new NpgsqlPoint({x: event.offsetX, y: event.offsetY}));
@@ -154,6 +154,9 @@
             context.font = "20px Arial";
             context.lineWidth = 1;
             context.textAlign = "center";
+            const textMeasurement = context.measureText(_cutPolygon.position);
+            const height = textMeasurement.fontBoundingBoxAscent + textMeasurement.fontBoundingBoxDescent;
+            if (!_cutPolygon.position.isEmpty()) context.strokeText(_cutPolygon.position, midX, midY - height);
             context.strokeText(_cutPolygon.name, midX, midY);
         }
     }
@@ -236,7 +239,7 @@
         if (_selectedPlant == undefined || _selectedImage == undefined) return;
         const client = new PhotoStitchingClient();
         const template = _extractionTemplates.find((et) => et.photoTourPlantFk == _selectedPlant?.id);
-        _cutPolygon = {points: [], name: ""};
+        _cutPolygon = {points: [], name: "", position: ""};
         await refreshImage();
         if (template == undefined) return;
         if (template.photoTripFk != _selectedPhotoTrip.tripId) {

--- a/GatewayApp/Frontend/Plantmonitor.Website/src/features/photoStitching/IrFineAdjustment.svelte
+++ b/GatewayApp/Frontend/Plantmonitor.Website/src/features/photoStitching/IrFineAdjustment.svelte
@@ -1,0 +1,42 @@
+<script lang="ts">
+    import {
+        ImageCropPreview,
+        PhotoStitchingClient,
+        PlantExtractionTemplateModel,
+        type PictureTripData
+    } from "~/services/GatewayAppApi";
+    import Checkbox from "../reuseableComponents/Checkbox.svelte";
+    import {selectedPhotoTourPlantInfo} from "../store";
+    let _isOpened = false;
+    export let _selectedTrip: PictureTripData | undefined;
+    export let _extractionTemplates: PlantExtractionTemplateModel[] = [];
+    let _imageCropPreview: ImageCropPreview | undefined;
+    async function UpdateCrop() {
+        if (_extractionTemplates.length == 0 || _selectedTrip == undefined || $selectedPhotoTourPlantInfo == undefined) return;
+        const extractionTemplateId = _extractionTemplates.find(
+            (et) => et.photoTourPlantFk == $selectedPhotoTourPlantInfo[0].id
+        )?.id;
+        const client = new PhotoStitchingClient();
+        _imageCropPreview = await client.croppedImageFor(extractionTemplateId, _selectedTrip.tripId);
+    }
+</script>
+
+<div style="height:50vh" class="col-md-12 d-flex flex-column">
+    <Checkbox label="Show IR fine adjustment" bind:value={_isOpened}></Checkbox>
+    {#if _isOpened}
+        {#if $selectedPhotoTourPlantInfo?.length != undefined && $selectedPhotoTourPlantInfo.length > 0}
+            <div>
+                Fine adjustement for {$selectedPhotoTourPlantInfo[0].name}
+                {$selectedPhotoTourPlantInfo[0].comment} - {$selectedPhotoTourPlantInfo[0].qrCode}
+            </div>
+            <div>{_selectedTrip?.timeStamp}</div>
+            <button on:click={UpdateCrop} class="btn btn-primary">Update Crop</button>
+        {/if}
+        {#if _imageCropPreview != undefined}
+            <div style="height: 480px;" class="col-md-12 row">
+                <img class="col-md-4" src="data:image/png;base64,{_imageCropPreview.irImage}" alt="IR Crop" />
+                <img class="col-md-4" src="data:image/png;base64,{_imageCropPreview.visImage}" alt="Vis Crop" />
+            </div>
+        {/if}
+    {/if}
+</div>

--- a/GatewayApp/Frontend/Plantmonitor.Website/src/features/photoStitching/IrFineAdjustment.svelte
+++ b/GatewayApp/Frontend/Plantmonitor.Website/src/features/photoStitching/IrFineAdjustment.svelte
@@ -87,10 +87,10 @@
 
 <div style="height:80vh" class="col-md-12 d-flex flex-column">
     {#if $selectedPhotoTourPlantInfo?.length != undefined && $selectedPhotoTourPlantInfo.length > 0}
-        <div>
-            Fine adjustement for {$selectedPhotoTourPlantInfo[0].name}
-            {$selectedPhotoTourPlantInfo[0].comment} - {$selectedPhotoTourPlantInfo[0].position}
-        </div>
+        {@const position = $selectedPhotoTourPlantInfo[0].position?.isEmpty()
+            ? ""
+            : "- " + $selectedPhotoTourPlantInfo[0].position}
+        <h4>Fine IR adjustment for {$selectedPhotoTourPlantInfo[0].name} {$selectedPhotoTourPlantInfo[0].comment} {position}</h4>
         <div class="col-md-12 row">
             <button
                 on:click={async () => {
@@ -98,7 +98,7 @@
                     _availableExtractionTemplates = uniqueExtractionOffsets();
                 }}
                 class="btn btn-primary col-md-2">Show Polygon</button>
-            <button on:click={() => storePolygonIrOffset()} class="btn btn-success col-md-2">Upate Offset</button>
+            <button on:click={() => storePolygonIrOffset()} class="btn btn-success col-md-2 ms-2">Update Offset</button>
         </div>
     {/if}
     {#if _imageCropPreview != undefined}
@@ -124,7 +124,7 @@
                     alt="Vis Crop" />
             </div>
             <div class="col-md-4" style="z-index: 1;"></div>
-            <div class="col-md-2 d-flex flex-column colm-3" style="height: 40vh;overflow-y:auto;z-index:1">
+            <div class="col-md-2 d-flex flex-column colm-3" style="height: 480px;overflow-y:auto;z-index:1">
                 {#each _availableExtractionTemplates as template}
                     <button
                         on:click={async () => {

--- a/GatewayApp/Frontend/Plantmonitor.Website/src/features/photoStitching/IrFineAdjustment.svelte
+++ b/GatewayApp/Frontend/Plantmonitor.Website/src/features/photoStitching/IrFineAdjustment.svelte
@@ -1,42 +1,117 @@
 <script lang="ts">
     import {
         ImageCropPreview,
+        IrOffsetFineAdjustement,
+        NpgsqlPoint,
         PhotoStitchingClient,
         PlantExtractionTemplateModel,
         type PictureTripData
     } from "~/services/GatewayAppApi";
-    import Checkbox from "../reuseableComponents/Checkbox.svelte";
     import {selectedPhotoTourPlantInfo} from "../store";
-    let _isOpened = false;
+    import {IrScalingHeight, IrScalingWidth} from "../deviceConfiguration/CvInterop";
     export let _selectedTrip: PictureTripData | undefined;
     export let _extractionTemplates: PlantExtractionTemplateModel[] = [];
     let _imageCropPreview: ImageCropPreview | undefined;
+    let _opacity = 1;
+    let _xOffset = 0;
+    let _yOffset = 0;
+    function keyPressed(evt: KeyboardEvent) {
+        if (evt.key == "ArrowRight") {
+            _xOffset += 1;
+            evt.preventDefault();
+        }
+        if (evt.key == "ArrowLeft") {
+            _xOffset -= 1;
+            evt.preventDefault();
+        }
+        if (evt.key == "ArrowUp") {
+            _yOffset -= 1;
+            evt.preventDefault();
+        }
+        if (evt.key == "ArrowDown") {
+            _yOffset += 1;
+            evt.preventDefault();
+        }
+        console.log({_xOffset, _yOffset});
+    }
     async function UpdateCrop() {
         if (_extractionTemplates.length == 0 || _selectedTrip == undefined || $selectedPhotoTourPlantInfo == undefined) return;
+        document.removeEventListener("keydown", keyPressed);
+        document.addEventListener("keydown", keyPressed);
         const extractionTemplateId = _extractionTemplates.find(
             (et) => et.photoTourPlantFk == $selectedPhotoTourPlantInfo[0].id
         )?.id;
         const client = new PhotoStitchingClient();
         _imageCropPreview = await client.croppedImageFor(extractionTemplateId, _selectedTrip.tripId);
+        _xOffset = 0;
+        _yOffset = 0;
+    }
+    function uniqueExtractionOffsets() {
+        const offsets = _extractionTemplates.map((et) => JSON.stringify(et.irBoundingBoxOffset));
+        return [...new Set(offsets)].map((o) => NpgsqlPoint.fromJS(JSON.parse(o))).toSorted((a, b) => a.x - b.x);
+    }
+    async function UpdateFineAdjustement(overwriteOffset: boolean, xOffset: number, yOffset: number) {
+        if (_extractionTemplates.length == 0 || _selectedTrip == undefined || $selectedPhotoTourPlantInfo == undefined) return;
+        const extractionTemplateId = _extractionTemplates.find(
+            (et) => et.photoTourPlantFk == $selectedPhotoTourPlantInfo[0].id
+        )?.id;
+        if (extractionTemplateId == undefined || _imageCropPreview == undefined) return;
+        const xRatio = _imageCropPreview?.irImageSize.x / IrScalingHeight;
+        const yRatio = _imageCropPreview?.irImageSize.y / IrScalingHeight;
+        if (!overwriteOffset) {
+            xOffset = (xOffset * xRatio) / 2;
+            yOffset = (yOffset * yRatio) / 4;
+        }
+        const client = new PhotoStitchingClient();
+        await client.updateIrOFfset(
+            new IrOffsetFineAdjustement({
+                extractionTemplateId: extractionTemplateId,
+                newIrOffset: new NpgsqlPoint({x: xOffset, y: yOffset}),
+                overwriteOffset: overwriteOffset
+            })
+        );
+        await UpdateCrop();
     }
 </script>
 
-<div style="height:50vh" class="col-md-12 d-flex flex-column">
-    <Checkbox label="Show IR fine adjustment" bind:value={_isOpened}></Checkbox>
-    {#if _isOpened}
-        {#if $selectedPhotoTourPlantInfo?.length != undefined && $selectedPhotoTourPlantInfo.length > 0}
-            <div>
-                Fine adjustement for {$selectedPhotoTourPlantInfo[0].name}
-                {$selectedPhotoTourPlantInfo[0].comment} - {$selectedPhotoTourPlantInfo[0].qrCode}
+<div style="height:80vh" class="col-md-12 d-flex flex-column">
+    {#if $selectedPhotoTourPlantInfo?.length != undefined && $selectedPhotoTourPlantInfo.length > 0}
+        <div>
+            Fine adjustement for {$selectedPhotoTourPlantInfo[0].name}
+            {$selectedPhotoTourPlantInfo[0].comment} - {$selectedPhotoTourPlantInfo[0].qrCode}
+        </div>
+        <div class="col-md-12 row">
+            <button on:click={UpdateCrop} class="btn btn-primary col-md-2">Show Polygon</button>
+            <button on:click={() => UpdateFineAdjustement(false, _xOffset, _yOffset)} class="btn btn-success col-md-2"
+                >Upate Offset</button>
+        </div>
+    {/if}
+    {#if _imageCropPreview != undefined}
+        <div>Current Offset (X,Y): {_imageCropPreview.currentOffset.x} {_imageCropPreview.currentOffset.y}</div>
+        <div class="col-md-12 row">
+            <div
+                class="col-md-6"
+                style="position: relative;"
+                on:wheel={(evt) => {
+                    _opacity = (_opacity + 1) % 2;
+                    evt.preventDefault();
+                }}>
+                <img
+                    style="position: absolute;height:{IrScalingHeight}px;left:{_xOffset}px;top:{_yOffset}px"
+                    src="data:image/png;base64,{_imageCropPreview.irImage}"
+                    alt="IR Crop" />
+                <img
+                    style="opacity:{_opacity};position: absolute;height:{IrScalingHeight}px;left:0px;top:0px"
+                    src="data:image/png;base64,{_imageCropPreview.visImage}"
+                    alt="Vis Crop" />
             </div>
-            <div>{_selectedTrip?.timeStamp}</div>
-            <button on:click={UpdateCrop} class="btn btn-primary">Update Crop</button>
-        {/if}
-        {#if _imageCropPreview != undefined}
-            <div style="height: 480px;" class="col-md-12 row">
-                <img class="col-md-4" src="data:image/png;base64,{_imageCropPreview.irImage}" alt="IR Crop" />
-                <img class="col-md-4" src="data:image/png;base64,{_imageCropPreview.visImage}" alt="Vis Crop" />
+            <div class="col-md-4"></div>
+            <div class="col-md-2 d-flex flex-column colm-3" style="height: 40vh;overflow-y:auto">
+                {#each uniqueExtractionOffsets() as template}
+                    <button on:click={() => UpdateFineAdjustement(true, template.x, template.y)} class="btn btn-dark"
+                        >Try Offset (X,Y): {template.x} {template.y}</button>
+                {/each}
             </div>
-        {/if}
+        </div>
     {/if}
 </div>

--- a/GatewayApp/Frontend/Plantmonitor.Website/src/features/photoStitching/IrFineAdjustment.svelte
+++ b/GatewayApp/Frontend/Plantmonitor.Website/src/features/photoStitching/IrFineAdjustment.svelte
@@ -22,7 +22,6 @@
     let _selectedTemplate: NpgsqlPoint | undefined;
     onMount(() => {
         _polygonUpdater = Task.createDebouncer(displayPolygonIrOffset, 150);
-        _availableExtractionTemplates = uniqueExtractionOffsets();
     });
     function keyPressed(evt: KeyboardEvent) {
         if (evt.key == "ArrowRight") {
@@ -93,8 +92,12 @@
             {$selectedPhotoTourPlantInfo[0].comment} - {$selectedPhotoTourPlantInfo[0].qrCode}
         </div>
         <div class="col-md-12 row">
-            <button on:click={async () => (_imageCropPreview = await loadNewPolygon())} class="btn btn-primary col-md-2"
-                >Show Polygon</button>
+            <button
+                on:click={async () => {
+                    _imageCropPreview = await loadNewPolygon();
+                    _availableExtractionTemplates = uniqueExtractionOffsets();
+                }}
+                class="btn btn-primary col-md-2">Show Polygon</button>
             <button on:click={() => storePolygonIrOffset()} class="btn btn-success col-md-2">Upate Offset</button>
         </div>
     {/if}

--- a/GatewayApp/Frontend/Plantmonitor.Website/src/features/photoStitching/IrFineAdjustment.svelte
+++ b/GatewayApp/Frontend/Plantmonitor.Website/src/features/photoStitching/IrFineAdjustment.svelte
@@ -89,7 +89,7 @@
     {#if $selectedPhotoTourPlantInfo?.length != undefined && $selectedPhotoTourPlantInfo.length > 0}
         <div>
             Fine adjustement for {$selectedPhotoTourPlantInfo[0].name}
-            {$selectedPhotoTourPlantInfo[0].comment} - {$selectedPhotoTourPlantInfo[0].qrCode}
+            {$selectedPhotoTourPlantInfo[0].comment} - {$selectedPhotoTourPlantInfo[0].position}
         </div>
         <div class="col-md-12 row">
             <button

--- a/GatewayApp/Frontend/Plantmonitor.Website/src/features/photoStitching/IrFineAdjustment.svelte
+++ b/GatewayApp/Frontend/Plantmonitor.Website/src/features/photoStitching/IrFineAdjustment.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
     import {
         ImageCropPreview,
-        IrOffsetFineAdjustement,
+        IrOffsetFineAdjustment,
         NpgsqlPoint,
         PhotoStitchingClient,
         PlantExtractionTemplateModel,
@@ -9,12 +9,21 @@
     } from "~/services/GatewayAppApi";
     import {selectedPhotoTourPlantInfo} from "../store";
     import {IrScalingHeight, IrScalingWidth} from "../deviceConfiguration/CvInterop";
+    import {Task} from "~/types/task";
+    import {onMount} from "svelte";
     export let _selectedTrip: PictureTripData | undefined;
     export let _extractionTemplates: PlantExtractionTemplateModel[] = [];
     let _imageCropPreview: ImageCropPreview | undefined;
     let _opacity = 1;
     let _xOffset = 0;
     let _yOffset = 0;
+    let _availableExtractionTemplates: NpgsqlPoint[] = [];
+    let _polygonUpdater: () => void;
+    let _selectedTemplate: NpgsqlPoint | undefined;
+    onMount(() => {
+        _polygonUpdater = Task.createDebouncer(displayPolygonIrOffset, 150);
+        _availableExtractionTemplates = uniqueExtractionOffsets();
+    });
     function keyPressed(evt: KeyboardEvent) {
         if (evt.key == "ArrowRight") {
             _xOffset += 1;
@@ -32,9 +41,9 @@
             _yOffset += 1;
             evt.preventDefault();
         }
-        console.log({_xOffset, _yOffset});
+        _polygonUpdater();
     }
-    async function UpdateCrop() {
+    async function loadNewPolygon() {
         if (_extractionTemplates.length == 0 || _selectedTrip == undefined || $selectedPhotoTourPlantInfo == undefined) return;
         document.removeEventListener("keydown", keyPressed);
         document.addEventListener("keydown", keyPressed);
@@ -42,35 +51,38 @@
             (et) => et.photoTourPlantFk == $selectedPhotoTourPlantInfo[0].id
         )?.id;
         const client = new PhotoStitchingClient();
-        _imageCropPreview = await client.croppedImageFor(extractionTemplateId, _selectedTrip.tripId);
+        const result = await client.croppedImageFor(extractionTemplateId, _selectedTrip.tripId, 0, 0);
         _xOffset = 0;
         _yOffset = 0;
+        _selectedTemplate == undefined;
+        return result;
+    }
+    async function displayPolygonIrOffset() {
+        if (_extractionTemplates.length == 0 || _selectedTrip == undefined || $selectedPhotoTourPlantInfo == undefined) return;
+        const extractionTemplateId = _extractionTemplates.find(
+            (et) => et.photoTourPlantFk == $selectedPhotoTourPlantInfo[0].id
+        )?.id;
+        const client = new PhotoStitchingClient();
+        _imageCropPreview = await client.croppedImageFor(extractionTemplateId, _selectedTrip.tripId, _xOffset, _yOffset);
     }
     function uniqueExtractionOffsets() {
         const offsets = _extractionTemplates.map((et) => JSON.stringify(et.irBoundingBoxOffset));
         return [...new Set(offsets)].map((o) => NpgsqlPoint.fromJS(JSON.parse(o))).toSorted((a, b) => a.x - b.x);
     }
-    async function UpdateFineAdjustement(overwriteOffset: boolean, xOffset: number, yOffset: number) {
+    async function storePolygonIrOffset() {
         if (_extractionTemplates.length == 0 || _selectedTrip == undefined || $selectedPhotoTourPlantInfo == undefined) return;
         const extractionTemplateId = _extractionTemplates.find(
             (et) => et.photoTourPlantFk == $selectedPhotoTourPlantInfo[0].id
         )?.id;
         if (extractionTemplateId == undefined || _imageCropPreview == undefined) return;
-        const xRatio = _imageCropPreview?.irImageSize.x / IrScalingHeight;
-        const yRatio = _imageCropPreview?.irImageSize.y / IrScalingHeight;
-        if (!overwriteOffset) {
-            xOffset = (xOffset * xRatio) / 2;
-            yOffset = (yOffset * yRatio) / 4;
-        }
         const client = new PhotoStitchingClient();
-        await client.updateIrOFfset(
-            new IrOffsetFineAdjustement({
+        await client.updateIrOffset(
+            new IrOffsetFineAdjustment({
                 extractionTemplateId: extractionTemplateId,
-                newIrOffset: new NpgsqlPoint({x: xOffset, y: yOffset}),
-                overwriteOffset: overwriteOffset
+                newIrOffset: _imageCropPreview.currentOffset
             })
         );
-        await UpdateCrop();
+        _imageCropPreview = await loadNewPolygon();
     }
 </script>
 
@@ -81,14 +93,17 @@
             {$selectedPhotoTourPlantInfo[0].comment} - {$selectedPhotoTourPlantInfo[0].qrCode}
         </div>
         <div class="col-md-12 row">
-            <button on:click={UpdateCrop} class="btn btn-primary col-md-2">Show Polygon</button>
-            <button on:click={() => UpdateFineAdjustement(false, _xOffset, _yOffset)} class="btn btn-success col-md-2"
-                >Upate Offset</button>
+            <button on:click={async () => (_imageCropPreview = await loadNewPolygon())} class="btn btn-primary col-md-2"
+                >Show Polygon</button>
+            <button on:click={() => storePolygonIrOffset()} class="btn btn-success col-md-2">Upate Offset</button>
         </div>
     {/if}
     {#if _imageCropPreview != undefined}
-        <div>Current Offset (X,Y): {_imageCropPreview.currentOffset.x} {_imageCropPreview.currentOffset.y}</div>
-        <div class="col-md-12 row">
+        <div>
+            Current Offset (X,Y): {_imageCropPreview.currentOffset.x.toFixed(1)},
+            {_imageCropPreview.currentOffset.y.toFixed(1)}
+        </div>
+        <div class="col-md-12 row" style="z-index: 0;">
             <div
                 class="col-md-6"
                 style="position: relative;"
@@ -97,7 +112,7 @@
                     evt.preventDefault();
                 }}>
                 <img
-                    style="position: absolute;height:{IrScalingHeight}px;left:{_xOffset}px;top:{_yOffset}px"
+                    style="position: absolute;height:{IrScalingHeight}px;left:0px;top:0px"
                     src="data:image/png;base64,{_imageCropPreview.irImage}"
                     alt="IR Crop" />
                 <img
@@ -105,11 +120,24 @@
                     src="data:image/png;base64,{_imageCropPreview.visImage}"
                     alt="Vis Crop" />
             </div>
-            <div class="col-md-4"></div>
-            <div class="col-md-2 d-flex flex-column colm-3" style="height: 40vh;overflow-y:auto">
-                {#each uniqueExtractionOffsets() as template}
-                    <button on:click={() => UpdateFineAdjustement(true, template.x, template.y)} class="btn btn-dark"
-                        >Try Offset (X,Y): {template.x} {template.y}</button>
+            <div class="col-md-4" style="z-index: 1;"></div>
+            <div class="col-md-2 d-flex flex-column colm-3" style="height: 40vh;overflow-y:auto;z-index:1">
+                {#each _availableExtractionTemplates as template}
+                    <button
+                        on:click={async () => {
+                            const defaultPoly = await loadNewPolygon();
+                            if (defaultPoly == undefined) return;
+                            _xOffset = defaultPoly.currentOffset.x - template.x;
+                            _yOffset = defaultPoly.currentOffset.y - template.y;
+                            _selectedTemplate = template;
+                            await displayPolygonIrOffset();
+                            _availableExtractionTemplates = _availableExtractionTemplates;
+                        }}
+                        class="btn btn-dark {_selectedTemplate == template ||
+                        (_imageCropPreview.currentOffset.x == template.x && _imageCropPreview.currentOffset.y == template.y)
+                            ? ''
+                            : 'opacity-50'}">
+                        Try Offset (X,Y): {template.x.toFixed(1)}, {template.y.toFixed(1)}</button>
                 {/each}
             </div>
         </div>

--- a/GatewayApp/Frontend/Plantmonitor.Website/src/services/GatewayAppApi.ts
+++ b/GatewayApp/Frontend/Plantmonitor.Website/src/services/GatewayAppApi.ts
@@ -3538,6 +3538,8 @@ export interface IPlantExtractionTemplateModel {
 export class ImageCropPreview implements IImageCropPreview {
     irImage!: string;
     visImage!: string;
+    currentOffset!: NpgsqlPoint;
+    irImageSize!: NpgsqlPoint;
 
     constructor(data?: IImageCropPreview) {
         if (data) {
@@ -3552,6 +3554,8 @@ export class ImageCropPreview implements IImageCropPreview {
         if (_data) {
             this.irImage = _data["IrImage"];
             this.visImage = _data["VisImage"];
+            this.currentOffset = _data["CurrentOffset"] ? NpgsqlPoint.fromJS(_data["CurrentOffset"]) : <any>undefined;
+            this.irImageSize = _data["IrImageSize"] ? NpgsqlPoint.fromJS(_data["IrImageSize"]) : <any>undefined;
         }
     }
 
@@ -3566,6 +3570,8 @@ export class ImageCropPreview implements IImageCropPreview {
         data = typeof data === 'object' ? data : {};
         data["IrImage"] = this.irImage;
         data["VisImage"] = this.visImage;
+        data["CurrentOffset"] = this.currentOffset ? this.currentOffset.toJSON() : <any>undefined;
+        data["IrImageSize"] = this.irImageSize ? this.irImageSize.toJSON() : <any>undefined;
         return data;
     }
 
@@ -3580,11 +3586,14 @@ export class ImageCropPreview implements IImageCropPreview {
 export interface IImageCropPreview {
     irImage: string;
     visImage: string;
+    currentOffset: NpgsqlPoint;
+    irImageSize: NpgsqlPoint;
 }
 
 export class IrOffsetFineAdjustement implements IIrOffsetFineAdjustement {
     extractionTemplateId!: number;
     newIrOffset!: NpgsqlPoint;
+    overwriteOffset!: boolean;
 
     constructor(data?: IIrOffsetFineAdjustement) {
         if (data) {
@@ -3599,6 +3608,7 @@ export class IrOffsetFineAdjustement implements IIrOffsetFineAdjustement {
         if (_data) {
             this.extractionTemplateId = _data["ExtractionTemplateId"];
             this.newIrOffset = _data["NewIrOffset"] ? NpgsqlPoint.fromJS(_data["NewIrOffset"]) : <any>undefined;
+            this.overwriteOffset = _data["OverwriteOffset"];
         }
     }
 
@@ -3613,6 +3623,7 @@ export class IrOffsetFineAdjustement implements IIrOffsetFineAdjustement {
         data = typeof data === 'object' ? data : {};
         data["ExtractionTemplateId"] = this.extractionTemplateId;
         data["NewIrOffset"] = this.newIrOffset ? this.newIrOffset.toJSON() : <any>undefined;
+        data["OverwriteOffset"] = this.overwriteOffset;
         return data;
     }
 
@@ -3627,6 +3638,7 @@ export class IrOffsetFineAdjustement implements IIrOffsetFineAdjustement {
 export interface IIrOffsetFineAdjustement {
     extractionTemplateId: number;
     newIrOffset: NpgsqlPoint;
+    overwriteOffset: boolean;
 }
 
 export class PlantImageSection implements IPlantImageSection {

--- a/GatewayApp/Frontend/Plantmonitor.Website/src/services/GatewayAppApi.ts
+++ b/GatewayApp/Frontend/Plantmonitor.Website/src/services/GatewayAppApi.ts
@@ -2326,10 +2326,7 @@ export class PhotoTourEvent implements IPhotoTourEvent {
     photoTourFk!: number;
     message!: string;
     timestamp!: Date;
-    referencesEvent!: number | undefined;
-    inverseReferencesEventNavigation!: PhotoTourEvent[];
     photoTourFkNavigation!: AutomaticPhotoTour;
-    referencesEventNavigation!: PhotoTourEvent | undefined;
     type!: PhotoTourEventType;
 
     constructor(data?: IPhotoTourEvent) {
@@ -2347,14 +2344,7 @@ export class PhotoTourEvent implements IPhotoTourEvent {
             this.photoTourFk = _data["PhotoTourFk"];
             this.message = _data["Message"];
             this.timestamp = _data["Timestamp"] ? new Date(_data["Timestamp"].toString()) : <any>undefined;
-            this.referencesEvent = _data["ReferencesEvent"];
-            if (Array.isArray(_data["InverseReferencesEventNavigation"])) {
-                this.inverseReferencesEventNavigation = [] as any;
-                for (let item of _data["InverseReferencesEventNavigation"])
-                    this.inverseReferencesEventNavigation!.push(PhotoTourEvent.fromJS(item));
-            }
             this.photoTourFkNavigation = _data["PhotoTourFkNavigation"] ? AutomaticPhotoTour.fromJS(_data["PhotoTourFkNavigation"]) : <any>undefined;
-            this.referencesEventNavigation = _data["ReferencesEventNavigation"] ? PhotoTourEvent.fromJS(_data["ReferencesEventNavigation"]) : <any>undefined;
             this.type = _data["Type"];
         }
     }
@@ -2372,14 +2362,7 @@ export class PhotoTourEvent implements IPhotoTourEvent {
         data["PhotoTourFk"] = this.photoTourFk;
         data["Message"] = this.message;
         data["Timestamp"] = this.timestamp ? this.timestamp.toISOString() : <any>undefined;
-        data["ReferencesEvent"] = this.referencesEvent;
-        if (Array.isArray(this.inverseReferencesEventNavigation)) {
-            data["InverseReferencesEventNavigation"] = [];
-            for (let item of this.inverseReferencesEventNavigation)
-                data["InverseReferencesEventNavigation"].push(item.toJSON());
-        }
         data["PhotoTourFkNavigation"] = this.photoTourFkNavigation ? this.photoTourFkNavigation.toJSON() : <any>undefined;
-        data["ReferencesEventNavigation"] = this.referencesEventNavigation ? this.referencesEventNavigation.toJSON() : <any>undefined;
         data["Type"] = this.type;
         return data;
     }
@@ -2397,10 +2380,7 @@ export interface IPhotoTourEvent {
     photoTourFk: number;
     message: string;
     timestamp: Date;
-    referencesEvent: number | undefined;
-    inverseReferencesEventNavigation: PhotoTourEvent[];
     photoTourFkNavigation: AutomaticPhotoTour;
-    referencesEventNavigation: PhotoTourEvent | undefined;
     type: PhotoTourEventType;
 }
 
@@ -2415,7 +2395,7 @@ export class PhotoTourPlant implements IPhotoTourPlant {
     id!: number;
     name!: string;
     comment!: string;
-    qrCode!: string | undefined;
+    position!: string | undefined;
     photoTourFk!: number;
     photoTourFkNavigation!: AutomaticPhotoTour;
     plantExtractionTemplates!: PlantExtractionTemplate[];
@@ -2434,7 +2414,7 @@ export class PhotoTourPlant implements IPhotoTourPlant {
             this.id = _data["Id"];
             this.name = _data["Name"];
             this.comment = _data["Comment"];
-            this.qrCode = _data["QrCode"];
+            this.position = _data["Position"];
             this.photoTourFk = _data["PhotoTourFk"];
             this.photoTourFkNavigation = _data["PhotoTourFkNavigation"] ? AutomaticPhotoTour.fromJS(_data["PhotoTourFkNavigation"]) : <any>undefined;
             if (Array.isArray(_data["PlantExtractionTemplates"])) {
@@ -2457,7 +2437,7 @@ export class PhotoTourPlant implements IPhotoTourPlant {
         data["Id"] = this.id;
         data["Name"] = this.name;
         data["Comment"] = this.comment;
-        data["QrCode"] = this.qrCode;
+        data["Position"] = this.position;
         data["PhotoTourFk"] = this.photoTourFk;
         data["PhotoTourFkNavigation"] = this.photoTourFkNavigation ? this.photoTourFkNavigation.toJSON() : <any>undefined;
         if (Array.isArray(this.plantExtractionTemplates)) {
@@ -2480,7 +2460,7 @@ export interface IPhotoTourPlant {
     id: number;
     name: string;
     comment: string;
-    qrCode: string | undefined;
+    position: string | undefined;
     photoTourFk: number;
     photoTourFkNavigation: AutomaticPhotoTour;
     plantExtractionTemplates: PlantExtractionTemplate[];
@@ -2492,9 +2472,9 @@ export class PlantExtractionTemplate implements IPlantExtractionTemplate {
     photoTourPlantFk!: number;
     photoBoundingBox!: NpgsqlPoint[];
     irBoundingBoxOffset!: NpgsqlPoint;
-    motorPosition!: number;
     boundingBoxHeight!: number;
     boundingBoxWidth!: number;
+    motorPosition!: number;
     photoTourPlantFkNavigation!: PhotoTourPlant;
     photoTripFkNavigation!: PhotoTourTrip;
 
@@ -2518,9 +2498,9 @@ export class PlantExtractionTemplate implements IPlantExtractionTemplate {
                     this.photoBoundingBox!.push(NpgsqlPoint.fromJS(item));
             }
             this.irBoundingBoxOffset = _data["IrBoundingBoxOffset"] ? NpgsqlPoint.fromJS(_data["IrBoundingBoxOffset"]) : <any>undefined;
-            this.motorPosition = _data["MotorPosition"];
             this.boundingBoxHeight = _data["BoundingBoxHeight"];
             this.boundingBoxWidth = _data["BoundingBoxWidth"];
+            this.motorPosition = _data["MotorPosition"];
             this.photoTourPlantFkNavigation = _data["PhotoTourPlantFkNavigation"] ? PhotoTourPlant.fromJS(_data["PhotoTourPlantFkNavigation"]) : <any>undefined;
             this.photoTripFkNavigation = _data["PhotoTripFkNavigation"] ? PhotoTourTrip.fromJS(_data["PhotoTripFkNavigation"]) : <any>undefined;
         }
@@ -2544,9 +2524,9 @@ export class PlantExtractionTemplate implements IPlantExtractionTemplate {
                 data["PhotoBoundingBox"].push(item.toJSON());
         }
         data["IrBoundingBoxOffset"] = this.irBoundingBoxOffset ? this.irBoundingBoxOffset.toJSON() : <any>undefined;
-        data["MotorPosition"] = this.motorPosition;
         data["BoundingBoxHeight"] = this.boundingBoxHeight;
         data["BoundingBoxWidth"] = this.boundingBoxWidth;
+        data["MotorPosition"] = this.motorPosition;
         data["PhotoTourPlantFkNavigation"] = this.photoTourPlantFkNavigation ? this.photoTourPlantFkNavigation.toJSON() : <any>undefined;
         data["PhotoTripFkNavigation"] = this.photoTripFkNavigation ? this.photoTripFkNavigation.toJSON() : <any>undefined;
         return data;
@@ -2566,9 +2546,9 @@ export interface IPlantExtractionTemplate {
     photoTourPlantFk: number;
     photoBoundingBox: NpgsqlPoint[];
     irBoundingBoxOffset: NpgsqlPoint;
-    motorPosition: number;
     boundingBoxHeight: number;
     boundingBoxWidth: number;
+    motorPosition: number;
     photoTourPlantFkNavigation: PhotoTourPlant;
     photoTripFkNavigation: PhotoTourTrip;
 }
@@ -3350,7 +3330,7 @@ export class PhotoTourPlantInfo implements IPhotoTourPlantInfo {
     id!: number;
     name!: string;
     comment!: string;
-    qrCode!: string | undefined;
+    position!: string | undefined;
     photoTourFk!: number;
     extractionMetaData!: ExtractionMetaData[];
 
@@ -3368,7 +3348,7 @@ export class PhotoTourPlantInfo implements IPhotoTourPlantInfo {
             this.id = _data["Id"];
             this.name = _data["Name"];
             this.comment = _data["Comment"];
-            this.qrCode = _data["QrCode"];
+            this.position = _data["Position"];
             this.photoTourFk = _data["PhotoTourFk"];
             if (Array.isArray(_data["ExtractionMetaData"])) {
                 this.extractionMetaData = [] as any;
@@ -3390,7 +3370,7 @@ export class PhotoTourPlantInfo implements IPhotoTourPlantInfo {
         data["Id"] = this.id;
         data["Name"] = this.name;
         data["Comment"] = this.comment;
-        data["QrCode"] = this.qrCode;
+        data["Position"] = this.position;
         data["PhotoTourFk"] = this.photoTourFk;
         if (Array.isArray(this.extractionMetaData)) {
             data["ExtractionMetaData"] = [];
@@ -3412,7 +3392,7 @@ export interface IPhotoTourPlantInfo {
     id: number;
     name: string;
     comment: string;
-    qrCode: string | undefined;
+    position: string | undefined;
     photoTourFk: number;
     extractionMetaData: ExtractionMetaData[];
 }
@@ -3766,7 +3746,7 @@ export interface IAddPlantModel {
 export class PlantModel implements IPlantModel {
     name!: string;
     comment!: string;
-    qrCode!: string;
+    position!: string;
 
     constructor(data?: IPlantModel) {
         if (data) {
@@ -3781,7 +3761,7 @@ export class PlantModel implements IPlantModel {
         if (_data) {
             this.name = _data["Name"];
             this.comment = _data["Comment"];
-            this.qrCode = _data["QrCode"];
+            this.position = _data["Position"];
         }
     }
 
@@ -3796,7 +3776,7 @@ export class PlantModel implements IPlantModel {
         data = typeof data === 'object' ? data : {};
         data["Name"] = this.name;
         data["Comment"] = this.comment;
-        data["QrCode"] = this.qrCode;
+        data["Position"] = this.position;
         return data;
     }
 
@@ -3811,7 +3791,7 @@ export class PlantModel implements IPlantModel {
 export interface IPlantModel {
     name: string;
     comment: string;
-    qrCode: string;
+    position: string;
 }
 
 export class MotorPosition implements IMotorPosition {

--- a/GatewayApp/Frontend/Plantmonitor.Website/src/services/GatewayAppApi.ts
+++ b/GatewayApp/Frontend/Plantmonitor.Website/src/services/GatewayAppApi.ts
@@ -727,9 +727,9 @@ export interface IPhotoStitchingClient {
 
     removePlantsFromTour(plantIds: number[]): Promise<void>;
 
-    croppedImageFor(extractionTemplateId?: number | undefined, photoTripId?: number | undefined): Promise<ImageCropPreview>;
+    croppedImageFor(extractionTemplateId?: number | undefined, photoTripId?: number | undefined, xOffset?: number | undefined, yOffset?: number | undefined): Promise<ImageCropPreview>;
 
-    updateIrOFfset(adjustment: IrOffsetFineAdjustement): Promise<void>;
+    updateIrOffset(adjustment: IrOffsetFineAdjustment): Promise<void>;
 
     associatePlantImageSection(section: PlantImageSection): Promise<void>;
 
@@ -928,7 +928,7 @@ export class PhotoStitchingClient extends GatewayAppApiBase implements IPhotoSti
         return Promise.resolve<void>(null as any);
     }
 
-    croppedImageFor(extractionTemplateId?: number | undefined, photoTripId?: number | undefined): Promise<ImageCropPreview> {
+    croppedImageFor(extractionTemplateId?: number | undefined, photoTripId?: number | undefined, xOffset?: number | undefined, yOffset?: number | undefined): Promise<ImageCropPreview> {
         let url_ = this.baseUrl + "/api/PhotoStitching/croppedimagefor?";
         if (extractionTemplateId === null)
             throw new Error("The parameter 'extractionTemplateId' cannot be null.");
@@ -938,6 +938,14 @@ export class PhotoStitchingClient extends GatewayAppApiBase implements IPhotoSti
             throw new Error("The parameter 'photoTripId' cannot be null.");
         else if (photoTripId !== undefined)
             url_ += "photoTripId=" + encodeURIComponent("" + photoTripId) + "&";
+        if (xOffset === null)
+            throw new Error("The parameter 'xOffset' cannot be null.");
+        else if (xOffset !== undefined)
+            url_ += "xOffset=" + encodeURIComponent("" + xOffset) + "&";
+        if (yOffset === null)
+            throw new Error("The parameter 'yOffset' cannot be null.");
+        else if (yOffset !== undefined)
+            url_ += "yOffset=" + encodeURIComponent("" + yOffset) + "&";
         url_ = url_.replace(/[?&]$/, "");
 
         let options_: RequestInit = {
@@ -972,7 +980,7 @@ export class PhotoStitchingClient extends GatewayAppApiBase implements IPhotoSti
         return Promise.resolve<ImageCropPreview>(null as any);
     }
 
-    updateIrOFfset(adjustment: IrOffsetFineAdjustement): Promise<void> {
+    updateIrOffset(adjustment: IrOffsetFineAdjustment): Promise<void> {
         let url_ = this.baseUrl + "/api/PhotoStitching/updateiroffset";
         url_ = url_.replace(/[?&]$/, "");
 
@@ -989,11 +997,11 @@ export class PhotoStitchingClient extends GatewayAppApiBase implements IPhotoSti
         return this.transformOptions(options_).then(transformedOptions_ => {
             return this.http.fetch(url_, transformedOptions_);
         }).then((_response: Response) => {
-            return this.transformResult(url_, _response, (_response: Response) => this.processUpdateIrOFfset(_response));
+            return this.transformResult(url_, _response, (_response: Response) => this.processUpdateIrOffset(_response));
         });
     }
 
-    protected processUpdateIrOFfset(response: Response): Promise<void> {
+    protected processUpdateIrOffset(response: Response): Promise<void> {
         const status = response.status;
         let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
         if (status === 200) {
@@ -3539,7 +3547,6 @@ export class ImageCropPreview implements IImageCropPreview {
     irImage!: string;
     visImage!: string;
     currentOffset!: NpgsqlPoint;
-    irImageSize!: NpgsqlPoint;
 
     constructor(data?: IImageCropPreview) {
         if (data) {
@@ -3555,7 +3562,6 @@ export class ImageCropPreview implements IImageCropPreview {
             this.irImage = _data["IrImage"];
             this.visImage = _data["VisImage"];
             this.currentOffset = _data["CurrentOffset"] ? NpgsqlPoint.fromJS(_data["CurrentOffset"]) : <any>undefined;
-            this.irImageSize = _data["IrImageSize"] ? NpgsqlPoint.fromJS(_data["IrImageSize"]) : <any>undefined;
         }
     }
 
@@ -3571,7 +3577,6 @@ export class ImageCropPreview implements IImageCropPreview {
         data["IrImage"] = this.irImage;
         data["VisImage"] = this.visImage;
         data["CurrentOffset"] = this.currentOffset ? this.currentOffset.toJSON() : <any>undefined;
-        data["IrImageSize"] = this.irImageSize ? this.irImageSize.toJSON() : <any>undefined;
         return data;
     }
 
@@ -3587,15 +3592,13 @@ export interface IImageCropPreview {
     irImage: string;
     visImage: string;
     currentOffset: NpgsqlPoint;
-    irImageSize: NpgsqlPoint;
 }
 
-export class IrOffsetFineAdjustement implements IIrOffsetFineAdjustement {
+export class IrOffsetFineAdjustment implements IIrOffsetFineAdjustment {
     extractionTemplateId!: number;
     newIrOffset!: NpgsqlPoint;
-    overwriteOffset!: boolean;
 
-    constructor(data?: IIrOffsetFineAdjustement) {
+    constructor(data?: IIrOffsetFineAdjustment) {
         if (data) {
             for (var property in data) {
                 if (data.hasOwnProperty(property))
@@ -3608,13 +3611,12 @@ export class IrOffsetFineAdjustement implements IIrOffsetFineAdjustement {
         if (_data) {
             this.extractionTemplateId = _data["ExtractionTemplateId"];
             this.newIrOffset = _data["NewIrOffset"] ? NpgsqlPoint.fromJS(_data["NewIrOffset"]) : <any>undefined;
-            this.overwriteOffset = _data["OverwriteOffset"];
         }
     }
 
-    static fromJS(data: any): IrOffsetFineAdjustement {
+    static fromJS(data: any): IrOffsetFineAdjustment {
         data = typeof data === 'object' ? data : {};
-        let result = new IrOffsetFineAdjustement();
+        let result = new IrOffsetFineAdjustment();
         result.init(data);
         return result;
     }
@@ -3623,22 +3625,20 @@ export class IrOffsetFineAdjustement implements IIrOffsetFineAdjustement {
         data = typeof data === 'object' ? data : {};
         data["ExtractionTemplateId"] = this.extractionTemplateId;
         data["NewIrOffset"] = this.newIrOffset ? this.newIrOffset.toJSON() : <any>undefined;
-        data["OverwriteOffset"] = this.overwriteOffset;
         return data;
     }
 
-    clone(): IrOffsetFineAdjustement {
+    clone(): IrOffsetFineAdjustment {
         const json = this.toJSON();
-        let result = new IrOffsetFineAdjustement();
+        let result = new IrOffsetFineAdjustment();
         result.init(json);
         return result;
     }
 }
 
-export interface IIrOffsetFineAdjustement {
+export interface IIrOffsetFineAdjustment {
     extractionTemplateId: number;
     newIrOffset: NpgsqlPoint;
-    overwriteOffset: boolean;
 }
 
 export class PlantImageSection implements IPlantImageSection {

--- a/GatewayApp/Frontend/Plantmonitor.Website/src/services/GatewayAppApi.ts
+++ b/GatewayApp/Frontend/Plantmonitor.Website/src/services/GatewayAppApi.ts
@@ -727,6 +727,10 @@ export interface IPhotoStitchingClient {
 
     removePlantsFromTour(plantIds: number[]): Promise<void>;
 
+    croppedImageFor(extractionTemplateId?: number | undefined, photoTripId?: number | undefined): Promise<ImageCropPreview>;
+
+    updateIrOFfset(adjustment: IrOffsetFineAdjustement): Promise<void>;
+
     associatePlantImageSection(section: PlantImageSection): Promise<void>;
 
     removePlantImageSections(sectionIds: number[]): Promise<void>;
@@ -910,6 +914,86 @@ export class PhotoStitchingClient extends GatewayAppApiBase implements IPhotoSti
     }
 
     protected processRemovePlantsFromTour(response: Response): Promise<void> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 200) {
+            return response.text().then((_responseText) => {
+            return;
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<void>(null as any);
+    }
+
+    croppedImageFor(extractionTemplateId?: number | undefined, photoTripId?: number | undefined): Promise<ImageCropPreview> {
+        let url_ = this.baseUrl + "/api/PhotoStitching/croppedimagefor?";
+        if (extractionTemplateId === null)
+            throw new Error("The parameter 'extractionTemplateId' cannot be null.");
+        else if (extractionTemplateId !== undefined)
+            url_ += "extractionTemplateId=" + encodeURIComponent("" + extractionTemplateId) + "&";
+        if (photoTripId === null)
+            throw new Error("The parameter 'photoTripId' cannot be null.");
+        else if (photoTripId !== undefined)
+            url_ += "photoTripId=" + encodeURIComponent("" + photoTripId) + "&";
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: RequestInit = {
+            method: "GET",
+            headers: {
+                "Accept": "application/json"
+            }
+        };
+
+        return this.transformOptions(options_).then(transformedOptions_ => {
+            return this.http.fetch(url_, transformedOptions_);
+        }).then((_response: Response) => {
+            return this.transformResult(url_, _response, (_response: Response) => this.processCroppedImageFor(_response));
+        });
+    }
+
+    protected processCroppedImageFor(response: Response): Promise<ImageCropPreview> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 200) {
+            return response.text().then((_responseText) => {
+            let result200: any = null;
+            let resultData200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result200 = ImageCropPreview.fromJS(resultData200);
+            return result200;
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<ImageCropPreview>(null as any);
+    }
+
+    updateIrOFfset(adjustment: IrOffsetFineAdjustement): Promise<void> {
+        let url_ = this.baseUrl + "/api/PhotoStitching/updateiroffset";
+        url_ = url_.replace(/[?&]$/, "");
+
+        const content_ = JSON.stringify(adjustment);
+
+        let options_: RequestInit = {
+            body: content_,
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+            }
+        };
+
+        return this.transformOptions(options_).then(transformedOptions_ => {
+            return this.http.fetch(url_, transformedOptions_);
+        }).then((_response: Response) => {
+            return this.transformResult(url_, _response, (_response: Response) => this.processUpdateIrOFfset(_response));
+        });
+    }
+
+    protected processUpdateIrOFfset(response: Response): Promise<void> {
         const status = response.status;
         let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
         if (status === 200) {
@@ -3449,6 +3533,100 @@ export interface IPlantExtractionTemplateModel {
     irBoundingBoxOffset: NpgsqlPoint;
     motorPosition: number;
     applicablePhotoTripFrom: Date;
+}
+
+export class ImageCropPreview implements IImageCropPreview {
+    irImage!: string;
+    visImage!: string;
+
+    constructor(data?: IImageCropPreview) {
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+    }
+
+    init(_data?: any) {
+        if (_data) {
+            this.irImage = _data["IrImage"];
+            this.visImage = _data["VisImage"];
+        }
+    }
+
+    static fromJS(data: any): ImageCropPreview {
+        data = typeof data === 'object' ? data : {};
+        let result = new ImageCropPreview();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["IrImage"] = this.irImage;
+        data["VisImage"] = this.visImage;
+        return data;
+    }
+
+    clone(): ImageCropPreview {
+        const json = this.toJSON();
+        let result = new ImageCropPreview();
+        result.init(json);
+        return result;
+    }
+}
+
+export interface IImageCropPreview {
+    irImage: string;
+    visImage: string;
+}
+
+export class IrOffsetFineAdjustement implements IIrOffsetFineAdjustement {
+    extractionTemplateId!: number;
+    newIrOffset!: NpgsqlPoint;
+
+    constructor(data?: IIrOffsetFineAdjustement) {
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+    }
+
+    init(_data?: any) {
+        if (_data) {
+            this.extractionTemplateId = _data["ExtractionTemplateId"];
+            this.newIrOffset = _data["NewIrOffset"] ? NpgsqlPoint.fromJS(_data["NewIrOffset"]) : <any>undefined;
+        }
+    }
+
+    static fromJS(data: any): IrOffsetFineAdjustement {
+        data = typeof data === 'object' ? data : {};
+        let result = new IrOffsetFineAdjustement();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["ExtractionTemplateId"] = this.extractionTemplateId;
+        data["NewIrOffset"] = this.newIrOffset ? this.newIrOffset.toJSON() : <any>undefined;
+        return data;
+    }
+
+    clone(): IrOffsetFineAdjustement {
+        const json = this.toJSON();
+        let result = new IrOffsetFineAdjustement();
+        result.init(json);
+        return result;
+    }
+}
+
+export interface IIrOffsetFineAdjustement {
+    extractionTemplateId: number;
+    newIrOffset: NpgsqlPoint;
 }
 
 export class PlantImageSection implements IPlantImageSection {

--- a/GatewayApp/Frontend/Plantmonitor.Website/src/types/task.ts
+++ b/GatewayApp/Frontend/Plantmonitor.Website/src/types/task.ts
@@ -1,7 +1,19 @@
 
 export class Task {
-	static delay = function (ms: number) {
-		return new Promise<void>(resolve => setTimeout(resolve, ms));
-	}
+    static delay = function (ms: number) {
+        return new Promise<void>(resolve => setTimeout(resolve, ms));
+    }
+    static createDebouncer = function (func: () => void, wait: number) {
+        return Task.debounce(func, wait, { counter: 0 });
+    }
+    static debounce = function (func: () => void, wait: number, countObject: { counter: number }) {
+        return () => {
+            countObject.counter++;
+            Task.delay(wait).then(() => {
+                countObject.counter--;
+                if (countObject.counter == 0) func();
+            });
+        }
+    }
 }
 


### PR DESCRIPTION


### Commit messages for #147

- 19e6f134f65bb6fa54cab6290ec31862df7ab9ee It seems to be a better solution to do the cropping on the server part. This has the advantage, that the actual code used by the virtual image worker for constructing the virtual image can be checked and aligned correctly.
This is a basic backend implementation for this
- d92f35a029317e029200fb0560897558e5fbeb61 frontend shows now some cropped images from desired plant and polygon
- 9d6c74095d73ec194a06a1ec82d7c96690e6158b offset is not working correctly
- 618e9fc655d30cc94465a893d9753dcbee58b87f calculating the crops on the server and displaying them is a much easier calculation wise, as the distance between the image border and the polygon to crop are not returned.
Without those distances the scaling cannot be reversed. So just calculate everything on the server and display the results. Is better for error finding anyway
- 24846727f6e79c9a90dcea8427ed2320038f9fca added checks to ensure that only mats with height and width are actually written to files or used for calculation
- a4078e161b499c590cd9d03addf055f61e985d92 the previous approach was not correctly calculating the width and height of the cropped images.
This approach should always work. When no mats exists with a size, a non empty size must be returned for the following calculations. Therefor 10 Pixels are the minimum requirement for height and width
- 14a0c67d31b30f9646a90f93b5482be9c1866143 Deleting of unnecesssary database column and renaming qr code to position, as the qr code feature is obsolete
- 792dc5dc3eb4c383470f5108d475e235f1f5c289 displaying the position over the name when showing the plants in the images for a fast way to check correct coordinates
- d0df18ed46019236f9bf0557b2c31782ccb5ecc7 minor usability fixes