### PR TITLE
Recognize and act on dirty motor positions

### DIFF
--- a/GatewayApp/Backend/Plantmonitor.Server/Features/DeviceControl/DeviceApi.cs
+++ b/GatewayApp/Backend/Plantmonitor.Server/Features/DeviceControl/DeviceApi.cs
@@ -2769,7 +2769,7 @@ namespace Plantmonitor.Server.Features.DeviceControl
     {
         [System.Text.Json.Serialization.JsonConstructor]
 
-        public MotorPosition(bool? @engaged, int? @position)
+        public MotorPosition(bool? @dirty, bool? @engaged, int? @position)
 
         {
 
@@ -2777,12 +2777,17 @@ namespace Plantmonitor.Server.Features.DeviceControl
 
             this.Position = @position;
 
+            this.Dirty = @dirty;
+
         }
         [System.Text.Json.Serialization.JsonPropertyName("engaged")]
         public bool? Engaged { get; init; }
 
         [System.Text.Json.Serialization.JsonPropertyName("position")]
         public int? Position { get; init; }
+
+        [System.Text.Json.Serialization.JsonPropertyName("dirty")]
+        public bool? Dirty { get; init; }
 
     }
 

--- a/GatewayApp/Backend/Plantmonitor.Server/Features/TemperatureMonitor/DeviceTemperatureWatcherWorker.cs
+++ b/GatewayApp/Backend/Plantmonitor.Server/Features/TemperatureMonitor/DeviceTemperatureWatcherWorker.cs
@@ -3,13 +3,13 @@ using Plantmonitor.Server.Features.AutomaticPhotoTour;
 
 namespace Plantmonitor.Server.Features.TemperatureMonitor;
 
-public class DeviceTemperatureWatcherWorker(IServiceScopeFactory scopeFactory) : IHostedService
+public class DeviceTemperatureWatcherWorker(IServiceScopeFactory scopeFactory, ILogger<DeviceTemperatureWatcherWorker> logger) : IHostedService
 {
     private Timer? _timer;
 
     public Task StartAsync(CancellationToken cancellationToken)
     {
-        _timer = new Timer(async _ => await RestartMeasurements(), default, 0, (int)TimeSpan.FromSeconds(5).TotalMilliseconds);
+        _timer = new Timer(async _ => await RestartMeasurements(), default, 0, (int)TimeSpan.FromSeconds(10).TotalMilliseconds);
         return Task.CompletedTask;
     }
 
@@ -23,11 +23,14 @@ public class DeviceTemperatureWatcherWorker(IServiceScopeFactory scopeFactory) :
         var expectedMeasurements = context.TemperatureMeasurements
             .Where(tm => !tm.Finished)
             .ToDictionary(tm => tm.Id);
+        logger.LogInformation("Checking Temperature devices");
         foreach (var measurement in measurements)
         {
             var correctRunningMeasurements = measurement.Select(m => expectedMeasurements.TryGetValue(m.MeasurementId, out var value) ? value : null);
+            logger.LogInformation("Checking Temperature measurement {measurement}", measurement.Key);
             if (correctRunningMeasurements.Any(rm => rm == null))
             {
+                logger.LogInformation("Stopping Temperature measurement {measurement}", measurement.Key);
                 temperatureWorker.StopMeasurement(measurement.Key);
                 continue;
             }
@@ -37,13 +40,16 @@ public class DeviceTemperatureWatcherWorker(IServiceScopeFactory scopeFactory) :
                     .OrderByDescending(tmv => tmv.Timestamp)
                     .FirstOrDefault(tmv => tmv.MeasurementFk == id);
                 var data = correctRunningMeasurements.First()!;
+                logger.LogInformation("Last Temperature received {timestamp} {temperature} {device}", lastTemperature?.Timestamp, lastTemperature?.Temperature, data.DeviceId);
                 if (lastTemperature != null && (lastTemperature.Timestamp - DateTime.UtcNow).TotalMinutes > 1)
                 {
+                    logger.LogWarning("Restart Temperature device {device}", data.DeviceId);
                     await restarter.RestartDevice(data.DeviceId.ToString(), data.PhotoTourFk, data.Comment);
                     break;
                 }
                 if (lastTemperature == null && (data.StartTime - DateTime.UtcNow).TotalMinutes > 1)
                 {
+                    logger.LogWarning("Restart Temperature device {device}", data.DeviceId);
                     await restarter.RestartDevice(data.DeviceId.ToString(), data.PhotoTourFk, data.Comment);
                     break;
                 }
@@ -51,11 +57,14 @@ public class DeviceTemperatureWatcherWorker(IServiceScopeFactory scopeFactory) :
         }
         foreach (var measurement in expectedMeasurements.Select(em => em.Value).GroupBy(em => em.DeviceId))
         {
+            logger.LogInformation("Checking expected measurement of {device}", measurement.Key);
             if (measurement.Any(m => m.IsThermalCamera())) continue;
             var okMeasurements = measurements.SelectMany(m => m.Select(x => x.MeasurementId)).ToHashSet();
             if (measurement.All(m => okMeasurements.Contains(m.Id))) continue;
+            logger.LogInformation("Resume measurement of {device}", measurement.Key);
             await temperatureWorker.ResumeMeasurement(measurement);
         }
+        logger.LogInformation("Temperature device checking finished");
         await Task.CompletedTask;
     }
 

--- a/PlantMonitorControl/ApiExceptionFilter.cs
+++ b/PlantMonitorControl/ApiExceptionFilter.cs
@@ -1,0 +1,20 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+
+namespace Plantmonitor.Server.Features.AppConfiguration
+{
+    public class ApiExceptionFilter(ILogger<ApiExceptionFilter> logger) : ExceptionFilterAttribute
+    {
+        public override void OnException(ExceptionContext context)
+        {
+            context.Result = context.Exception switch
+            {
+                _ => new JsonResult(context.Exception.Message) { StatusCode = StatusCodes.Status500InternalServerError },
+            };
+            logger.Log(LogLevel.Error, "Message: {message}", context.Exception.Message);
+            logger.Log(LogLevel.Error, "InnerMessage: {message}", context.Exception.InnerException?.Message);
+            logger.Log(LogLevel.Error, "Stacktrace: {trace}", context.Exception.StackTrace);
+            base.OnException(context);
+        }
+    }
+}

--- a/PlantMonitorControl/Features/MotorMovement/MotorMovementController.cs
+++ b/PlantMonitorControl/Features/MotorMovement/MotorMovementController.cs
@@ -2,7 +2,7 @@
 
 namespace PlantMonitorControl.Features.MotorMovement;
 
-public record struct MotorPosition(bool Engaged, int Position);
+public record struct MotorPosition(bool Engaged, int Position, bool Dirty);
 
 [ApiController]
 [Route("api/[controller]")]

--- a/PlantMonitorControl/Program.cs
+++ b/PlantMonitorControl/Program.cs
@@ -1,4 +1,5 @@
-﻿using PlantMonitorControl.Features.AppsettingsConfiguration;
+﻿using Plantmonitor.Server.Features.AppConfiguration;
+using PlantMonitorControl.Features.AppsettingsConfiguration;
 using PlantMonitorControl.Features.HealthChecking;
 using PlantMonitorControl.Features.ImageTaking;
 using PlantMonitorControl.Features.MeasureTemperature;
@@ -74,6 +75,10 @@ builder.Services.AddSignalR().AddMessagePackProtocol();
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
+builder.Services.AddMvc(options =>
+{
+    options.Filters.Add<ApiExceptionFilter>();
+});
 
 var app = builder.Build();
 


### PR DESCRIPTION


### Commit messages for #176

- 36eedef3df4ae1b4b93ea82e8401db0b613e1350 added a dirty flag, which is persisted during the start of each movement and removed after the end of the movement.
This should make it impossible to move the motor, when it is currently moving or when the device faulted during a previous movement and is now in an unknown state
- 87e658906906a93c632249116e084a026b2b1b0a photo tours are now aborted, if a dirty position of the motor is detected
- 46dea46216f54a1fc362b4d8af39278ee66dc9d4 added logging to checking of temperature devices