### PR TITLE
ir images are now padded, if they are out of bounds

### DIFF
--- a/GatewayApp/Backend/Plantmonitor.Server.Tests/Features/AutomaticPhotoTourTests/AutomaticPhotoTourWorkerTests.cs
+++ b/GatewayApp/Backend/Plantmonitor.Server.Tests/Features/AutomaticPhotoTourTests/AutomaticPhotoTourWorkerTests.cs
@@ -128,6 +128,7 @@ public class AutomaticPhotoTourWorkerTests
             (irFolder, visFolder) = await TakePhotos(sut, 1, _context, _pictureStreamer, _deviceApi, deviceHealth);
         }
         PhotoTaking().RunInBackground(ex => throw ex);
+        await Task.Delay(100);
         await _motorClient.Received().MovemotorAsync(-1000, Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>(), (int)(200 * 1.05f), (int)(-200 * 1.05f));
         await _motorClient.Received().MovemotorAsync(200, Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>(), (int)(200 * 1.05f), (int)(-200 * 1.05f));
         await _motorClient.ReceivedWithAnyArgs(2).MovemotorAsync(default, Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>(), default, default);
@@ -158,7 +159,7 @@ public class AutomaticPhotoTourWorkerTests
         await _irClient.Received(1).KillcameraAsync();
         await _visClient.Received(1).KillcameraAsync();
 
-        _context.PhotoTourEvents.Count().Should().Be(0);
+        _context.PhotoTourEvents.Count().Should().Be(8);
         visFolder.Should().Be("visfolder");
         irFolder.Should().Be("irfolder");
     }

--- a/GatewayApp/Backend/Plantmonitor.Server.Tests/Features/ImageStitching/ImageCropperTests.cs
+++ b/GatewayApp/Backend/Plantmonitor.Server.Tests/Features/ImageStitching/ImageCropperTests.cs
@@ -128,8 +128,9 @@ public class ImageCropperTests
         var visFile = $"{applicationPath}/PlantMonitorControl.Tests/TestData/CropTest/2024-07-28_20-26-10-207_-6000_0.jpg";
         var result = sut.CropImages(visFile, irFile, s_singlePlantBottomMiddlePolygon_1WeekLaterAndMoved, new(-1000, -1000), 960);
         sut.ApplyIrColorMap(result.IrImage!);
-        result.IrImage!.Height.Should().Be(0);
-        result.IrImage!.Width.Should().Be(0);
+        result.IrImage!.Height.Should().Be(232);
+        result.IrImage!.Width.Should().Be(232);
+        result.IrImage!.ShowImage("OutOfRange", 100);
         result.IrImage!.Dispose();
         result.VisImage.Dispose();
     }
@@ -145,6 +146,91 @@ public class ImageCropperTests
         sut.ApplyIrColorMap(result.IrImage!);
         result.IrImage!.ShowImage("CroppedIR");
         result.VisImage.ShowImage("CroppedVis");
+        result.IrImage!.Dispose();
+        result.VisImage.Dispose();
+    }
+
+    [Fact]
+    public void CropImage_IROutOfRange_Left_ShouldHaveSameSize()
+    {
+        var sut = CreateImageCropper();
+        var applicationPath = Directory.GetCurrentDirectory().GetApplicationRootGitPath();
+        var irFile = $"{applicationPath}/PlantMonitorControl.Tests/TestData/CropTest/2024-07-28_20-33-19-047_-6000_29710.rawir";
+        var visFile = $"{applicationPath}/PlantMonitorControl.Tests/TestData/CropTest/2024-07-28_20-26-10-207_-6000_0.jpg";
+        var result = sut.CropImages(visFile, irFile, s_singlePlantBottomMiddlePolygon_1WeekLaterAndMoved, new(400, 150), 960);//new(121, 39));
+        sut.ApplyIrColorMap(result.IrImage!);
+        result.IrImage!.ShowImage("CroppedIR");
+        result.VisImage.ShowImage("CroppedVis");
+        result.IrImage!.Height.Should().Be(result.VisImage.Height);
+        result.IrImage!.Width.Should().Be(result.VisImage.Width);
+        result.IrImage!.Dispose();
+        result.VisImage.Dispose();
+    }
+
+    [Fact]
+    public void CropImage_IROutOfRange_TopRight_ShouldHaveSameSize()
+    {
+        var sut = CreateImageCropper();
+        var applicationPath = Directory.GetCurrentDirectory().GetApplicationRootGitPath();
+        var irFile = $"{applicationPath}/PlantMonitorControl.Tests/TestData/CropTest/2024-07-28_20-33-19-047_-6000_29710.rawir";
+        var visFile = $"{applicationPath}/PlantMonitorControl.Tests/TestData/CropTest/2024-07-28_20-26-10-207_-6000_0.jpg";
+        var result = sut.CropImages(visFile, irFile, s_singlePlantBottomMiddlePolygon_1WeekLaterAndMoved, new(-200, 300), 960);//new(121, 39));
+        sut.ApplyIrColorMap(result.IrImage!);
+        result.IrImage!.ShowImage("CroppedIR");
+        result.VisImage.ShowImage("CroppedVis");
+        result.IrImage!.Height.Should().Be(result.VisImage.Height);
+        result.IrImage!.Width.Should().Be(result.VisImage.Width);
+        result.IrImage!.Dispose();
+        result.VisImage.Dispose();
+    }
+
+    [Fact]
+    public void CropImage_IROutOfRange_Right_ShouldHaveSameSize()
+    {
+        var sut = CreateImageCropper();
+        var applicationPath = Directory.GetCurrentDirectory().GetApplicationRootGitPath();
+        var irFile = $"{applicationPath}/PlantMonitorControl.Tests/TestData/CropTest/2024-07-28_20-33-19-047_-6000_29710.rawir";
+        var visFile = $"{applicationPath}/PlantMonitorControl.Tests/TestData/CropTest/2024-07-28_20-26-10-207_-6000_0.jpg";
+        var result = sut.CropImages(visFile, irFile, s_singlePlantBottomMiddlePolygon_1WeekLaterAndMoved, new(-200, 150), 960);//new(121, 39));
+        sut.ApplyIrColorMap(result.IrImage!);
+        result.IrImage!.ShowImage("CroppedIR");
+        result.VisImage.ShowImage("CroppedVis");
+        result.IrImage!.Height.Should().Be(result.VisImage.Height);
+        result.IrImage!.Width.Should().Be(result.VisImage.Width);
+        result.IrImage!.Dispose();
+        result.VisImage.Dispose();
+    }
+
+    [Fact]
+    public void CropImage_IROutOfRange_Top_ShouldHaveSameSize()
+    {
+        var sut = CreateImageCropper();
+        var applicationPath = Directory.GetCurrentDirectory().GetApplicationRootGitPath();
+        var irFile = $"{applicationPath}/PlantMonitorControl.Tests/TestData/CropTest/2024-07-28_20-33-19-047_-6000_29710.rawir";
+        var visFile = $"{applicationPath}/PlantMonitorControl.Tests/TestData/CropTest/2024-07-28_20-26-10-207_-6000_0.jpg";
+        var result = sut.CropImages(visFile, irFile, s_singlePlantBottomMiddlePolygon_1WeekLaterAndMoved, new(100, 300), 960);//new(121, 39));
+        sut.ApplyIrColorMap(result.IrImage!);
+        result.IrImage!.ShowImage("CroppedIR");
+        result.VisImage.ShowImage("CroppedVis");
+        result.IrImage!.Height.Should().Be(result.VisImage.Height);
+        result.IrImage!.Width.Should().Be(result.VisImage.Width);
+        result.IrImage!.Dispose();
+        result.VisImage.Dispose();
+    }
+
+    [Fact]
+    public void CropImage_IROutOfRange_Bottom_ShouldHaveSameSize()
+    {
+        var sut = CreateImageCropper();
+        var applicationPath = Directory.GetCurrentDirectory().GetApplicationRootGitPath();
+        var irFile = $"{applicationPath}/PlantMonitorControl.Tests/TestData/CropTest/2024-07-28_20-33-19-047_-6000_29710.rawir";
+        var visFile = $"{applicationPath}/PlantMonitorControl.Tests/TestData/CropTest/2024-07-28_20-26-10-207_-6000_0.jpg";
+        var result = sut.CropImages(visFile, irFile, s_singlePlantBottomMiddlePolygon_1WeekLaterAndMoved, new(170, -200), 960);//new(121, 39));
+        sut.ApplyIrColorMap(result.IrImage!);
+        result.IrImage!.ShowImage("CroppedIR");
+        result.VisImage.ShowImage("CroppedVis");
+        result.IrImage!.Height.Should().Be(result.VisImage.Height);
+        result.IrImage!.Width.Should().Be(result.VisImage.Width);
         result.IrImage!.Dispose();
         result.VisImage.Dispose();
     }

--- a/GatewayApp/Backend/Plantmonitor.Server/Features/AutomaticPhotoTour/DeviceRestarter.cs
+++ b/GatewayApp/Backend/Plantmonitor.Server/Features/AutomaticPhotoTour/DeviceRestarter.cs
@@ -56,7 +56,7 @@ public class DeviceRestarter(IServiceScopeFactory scopeFactory) : IDeviceRestart
         var irImage = irTest.Result?.Stream.ConvertToArray() ?? [];
         var visTest = await deviceApi.VisImageTakingClient(deviceHealth.Ip).PreviewimageAsync().Try();
         var visImage = visTest.Result?.Stream.ConvertToArray() ?? [];
-        if ((hasIrCamera && irImage.Length < 100 && !irTest.Error.IsEmpty()) || visImage.Length < 100 || !visTest.Error.IsEmpty())
+        if ((hasIrCamera && irImage.Length < 100) || (hasIrCamera && !irTest.Error.IsEmpty()) || visImage.Length < 100 || !visTest.Error.IsEmpty())
         {
             var notWorkingCameras = new List<string>()
                 .PushIf("IR", _ => irImage.Length < 100)

--- a/GatewayApp/Backend/Plantmonitor.Server/Features/ImageStitching/ImageCropper.cs
+++ b/GatewayApp/Backend/Plantmonitor.Server/Features/ImageStitching/ImageCropper.cs
@@ -45,7 +45,7 @@ public class ImageCropper() : IImageCropper
                 var value = ZeroDegreeCelsius;
                 if (rawValue is float) value = (int)(float)rawValue;
                 else if (rawValue is int) value = (int)rawValue;
-                value -= ZeroDegreeCelsius;
+                if (value != 0) value -= ZeroDegreeCelsius;
                 var intValue = (value / 100);
                 var decimalValue = (int)(((value / 100f) - intValue) * 100);
                 integerData[index] = (byte)intValue;
@@ -70,7 +70,7 @@ public class ImageCropper() : IImageCropper
             Log.Logger.Error("decimal channel was over 100: {from}-{to}", decimalRange.Min, decimalRange.Max);
             throw new Exception("decimal channel was over 100");
         }
-        if (fullRange.Min < 5 || fullRange.Max > 100)
+        if (fullRange.Min < 0 || fullRange.Max > 100)
         {
             Log.Logger.Error("integer channel was not in bounds: {from}-{to}", fullRange.Min, fullRange.Max);
             throw new Exception("integer channel was not in bounds: {from}-{to}");
@@ -165,7 +165,7 @@ public class ImageCropper() : IImageCropper
         var padTopSign = irPolygon.Min(p => p.Y) < 0 ? -1 : 1;
         var xPadding = Math.Max(0, padLeftSign * (irCrop.Width - visCrop.Width));
         var yPadding = Math.Max(0, padTopSign * (irCrop.Height - visCrop.Height));
-        var resultData = new float[result.Width * result.Cols];
+        var resultData = new float[result.Height * result.Width];
         var irCropData = irCrop.GetData(true);
         for (var row = 0; row < irCrop.Rows; row++)
         {


### PR DESCRIPTION


### Commit messages for #182

- d184f22515e8b032fb1eecc853e4b7ac66e7f0b7 Padding should now work. Out of bounds pictures are now not clipped anymore, but padded with zeros instead. This leads to some regressions in the virtual image creation, as it does not expect zeros as temperatures
- f040ecc95beedadb2384b21fb43cc2e137e546a5 fix of remaining errors
- ce89e54a7b9366dfa526ee07256ebe250c5efe11 fixed all tests, which were broken from previous logging changes.
See https://github.com/Machriam/PlantMonitor/issues/169 for behaviour changes