### PR TITLE
Correction of ir data length

### DIFF
--- a/GatewayApp/Backend/Plantmonitor.Server/Features/CustomTourCreation/CustomTourCreationController.cs
+++ b/GatewayApp/Backend/Plantmonitor.Server/Features/CustomTourCreation/CustomTourCreationController.cs
@@ -80,7 +80,7 @@ public class CustomTourCreationController(IEnvironmentConfiguration configuratio
             }
             else if (fileData.Info.GetCameraType() == CameraType.IR && !newFolderEntry.VisPath.IsEmpty())
             {
-                if (fileData.Path.GetBytesFromIrFilePath(out _).Bytes.Length != ImageConstants.IrPixelCount)
+                if (fileData.Path.GetBytesFromIrFilePath(out _).Bytes.Length != ImageConstants.IrPixelCount * sizeof(int))
                 {
                     File.Delete(fileData.Path);
                     continue;


### PR DESCRIPTION


### Commit messages for #208

- 7e366ad7ecc3d6b32fdb1ea0fdafbd4668619a31 temperatures are stored as integer values, this means the byte length must be multiplied by 4 for a proper check